### PR TITLE
feat: 견적, 견적 요청 스키마 수정

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
     "printWidth": 100,
-    "tabWidth": 4,
+    "tabWidth": 2,
     "useTabs": false,
     "semi": true,
     "singleQuote": false,

--- a/prisma/migrations/20250710023047_delete_request_model_and_modify_estimate_model/migration.sql
+++ b/prisma/migrations/20250710023047_delete_request_model_and_modify_estimate_model/migration.sql
@@ -1,0 +1,47 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `createdAt` on the `Estimate` table. All the data in the column will be lost.
+  - You are about to drop the column `isDone` on the `Estimate` table. All the data in the column will be lost.
+  - You are about to drop the column `requestId` on the `Estimate` table. All the data in the column will be lost.
+  - You are about to drop the `Request` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `confirmedAt` to the `Estimate` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `fromAddress` to the `Estimate` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `moveDate` to the `Estimate` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `moveType` to the `Estimate` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `toAddress` to the `Estimate` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "EstimateStatus" AS ENUM ('PENDING', 'CONFIRMED', 'REJECTED', 'DONE');
+
+-- DropForeignKey
+ALTER TABLE "Estimate" DROP CONSTRAINT "Estimate_requestId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Request" DROP CONSTRAINT "Request_clientId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Request" DROP CONSTRAINT "Request_moverId_fkey";
+
+-- AlterTable
+ALTER TABLE "Estimate" DROP COLUMN "createdAt",
+DROP COLUMN "isDone",
+DROP COLUMN "requestId",
+ADD COLUMN     "comment" TEXT,
+ADD COLUMN     "confirmedAt" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "fromAddress" TEXT NOT NULL,
+ADD COLUMN     "isDesignated" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "moveDate" TIMESTAMP(3) NOT NULL,
+ADD COLUMN     "moveType" "MoveType" NOT NULL,
+ADD COLUMN     "requestedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "status" "EstimateStatus" NOT NULL DEFAULT 'PENDING',
+ADD COLUMN     "toAddress" TEXT NOT NULL,
+ALTER COLUMN "moverId" DROP NOT NULL,
+ALTER COLUMN "price" DROP NOT NULL;
+
+-- DropTable
+DROP TABLE "Request";
+
+-- DropEnum
+DROP TYPE "RequestStatus";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,6 @@ model Client {
   serviceType    MoveType[]
   livingArea     Region[]
   favorites      Favorite[]
-  requests       Request[]
   estimates      Estimate[]
   reviews        Review[]
   notifications  Notification[]
@@ -54,7 +53,6 @@ model Mover {
   estimateCount       Int            @default(0)
   averageReviewRating Float          @default(0)
   reviewCount         Int            @default(0)
-  requests            Request[]
   estimates           Estimate[]
   reviews             Review[]
   favorites           Favorite[]
@@ -68,37 +66,24 @@ model Region {
   movers     Mover[]
 }
 
-model Request {
-  id             String        @id @default(uuid())
-  clientId       String
-  moverId        String?
-  moveType       MoveType
-  moveDate       DateTime
-  fromAddress    String
-  toAddress      String
-  isDesignated   Boolean       @default(false)
-  requestStatus  RequestStatus @default(PENDING)
-  rejectedReason String?
-  requestedAt    DateTime      @default(now())
-
-  client    Client     @relation(fields: [clientId], references: [id], onDelete: Cascade)
-  mover     Mover?     @relation(fields: [moverId], references: [id], onDelete: Cascade)
-  estimates Estimate[]
-}
-
 model Estimate {
-  id        String   @id @default(uuid())
-  requestId String
-  clientId  String
-  moverId   String
-  price     Int
-  isDone    Boolean  @default(false)
-  createdAt DateTime @default(now())
+  id           String         @id @default(uuid())
+  clientId     String
+  moverId      String?
+  moveType     MoveType
+  moveDate     DateTime
+  fromAddress  String
+  toAddress    String
+  isDesignated Boolean        @default(false)
+  price        Int?
+  status       EstimateStatus @default(PENDING)
+  comment      String?
+  requestedAt  DateTime       @default(now())
+  confirmedAt  DateTime       @updatedAt
 
-  review   Review?
-  requests Request @relation(fields: [requestId], references: [id], onDelete: Cascade)
-  client   Client  @relation(fields: [clientId], references: [id], onDelete: Cascade)
-  mover    Mover   @relation(fields: [moverId], references: [id], onDelete: Cascade)
+  client Client  @relation(fields: [clientId], references: [id], onDelete: Cascade)
+  mover  Mover?  @relation(fields: [moverId], references: [id], onDelete: Cascade)
+  review Review?
 }
 
 model Review {
@@ -152,10 +137,11 @@ enum MoveType {
   OFFICE
 }
 
-enum RequestStatus {
+enum EstimateStatus {
   PENDING
   CONFIRMED
   REJECTED
+  DONE
 }
 
 enum NotificationType {


### PR DESCRIPTION
## 작업 개요
- 견적 요청(`Request`) 모델 삭제
- 견적(`Estimate`) 스키마와 통합

---

## 작업 상세 내용
- [x] 기존 `Request` 모델에 있던 필드 `Estimate`에 추가
- [x] 견적 요청 시 `clientId`, `moveType`, `moveDate`, `fromAddress`, `toAddress` 전달
- [x] 나머지 필드 default 혹은 옵셔널 처리  

---

## 🗂️ 수정한 파일
- `schema.prisma`
- `.prettierrc`

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항
- 들여쓰기 폭이 너무 큰것같아서 `.prettierrc` tabWidth: 2로 수정했습니다.
