### PR TITLE
feat: 기사님 프로필 등록/수정 API 구현

### DIFF
--- a/http/auth.http
+++ b/http/auth.http
@@ -17,8 +17,8 @@ POST http://localhost:4000/auth/signin/mover
 Content-Type: application/json
 
 {
-        "email": "test8@test.com", 
-     "password": "a88888888"
+        "email": "test6@test.com", 
+     "password": "a66666666"
 }
 
 ### 일반 회원 회원가입(local)

--- a/http/auth.http
+++ b/http/auth.http
@@ -5,11 +5,11 @@ POST http://localhost:4000/auth/signup/mover
 Content-Type: application/json
 
 {
-    "name": "t6",
-     "email": "test6@test.com", 
-     "phone": "01066666666", 
-     "password": "a66666666",
-       "passwordConfirmation":"a66666666"
+    "name": "t8",
+     "email": "test8@test.com", 
+     "phone": "01088888888", 
+     "password": "a88888888",
+       "passwordConfirmation":"a88888888"
 }
 
 ###기사님 로그인(local)
@@ -17,8 +17,8 @@ POST http://localhost:4000/auth/signin/mover
 Content-Type: application/json
 
 {
-     "email": "test6@test.com", 
-      "password": "a66666666"
+        "email": "test8@test.com", 
+     "password": "a88888888"
 }
 
 ### 일반 회원 회원가입(local)

--- a/http/auth.http
+++ b/http/auth.http
@@ -17,8 +17,8 @@ POST http://localhost:4000/auth/signin/mover
 Content-Type: application/json
 
 {
-     "email": "test5@test.com", 
-     "password": "a5555555"
+     "email": "test6@test.com", 
+      "password": "a66666666"
 }
 
 ### 일반 회원 회원가입(local)

--- a/http/auth.http
+++ b/http/auth.http
@@ -27,8 +27,8 @@ Content-Type: application/json
 
 {
      "name": "일반인",
-     "email": "test5@test.com", 
-     "phone": "03112345679", 
+     "email": "test4@test.com", 
+     "phoneNumber": "03112345678", 
      "password": "asdf1234",
      "passwordConfirmation": "asdf1234"
 }
@@ -38,7 +38,7 @@ POST http://localhost:4000/auth/signin/client
 Content-Type: application/json
 
 {
-     "email": "test5@test.com", 
+     "email": "test4@test.com", 
      "password": "asdf1234"
 }
 
@@ -50,4 +50,4 @@ Cookie: refreshToken=값
 ### 사용자 불러오기
 GET http://localhost:4000/auth
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI2MmRkNTY2OC02Nzg3LTQ1MTktYjliMS0zN2Y4OGMyY2QxN2UiLCJlbWFpbCI6InRlc3Q0QHRlc3QuY29tIiwibmFtZSI6IuydvOuwmOyduCIsInVzZXJUeXBlIjoiY2xpZW50IiwiaWF0IjoxNzUyMjE0NjM5LCJleHAiOjE3NTIyMTgyMzl9.Tvtjd5YECuv3JGN-YfAXvHEYApqC6LRf9MtpjtSB8SQ
+Authorization: Bearer 값

--- a/http/profile.http
+++ b/http/profile.http
@@ -1,9 +1,9 @@
-@token={{$dotenv TOKEN}}
+# @token={{$dotenv TOKEN}}
 
 ### 기사님 프로필 등록
-POST http://localhost:3000/profile/movers
+POST http://localhost:3000/profile/1/mover
 Content-Type: application/json
-Authorization: Bearer {{token}}
+Authorization: Bearer 
 
 {
      "image": , 

--- a/http/profile.http
+++ b/http/profile.http
@@ -1,5 +1,4 @@
-@token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJlZGFkMDM0Mi1lODI4LTRjNTItOWIzMy0xYTkzOGQ5Mzk5NGMiLCJlbWFpbCI6InRlc3Q4QHRlc3QuY29tIiwibmFtZSI6InQ4IiwidXNlclR5cGUiOiJtb3ZlciIsImlhdCI6MTc1MjQ3OTE2MSwiZXhwIjoxNzUyNDgyNzYxfQ.JArjBSy-xzqdjV_A6mDW24V9LDfTzBpIwewyvBR-T4s
-
+@token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI3NzNmOTI2NC1hMGVkLTQxMzItYTQzNC04MzcwZDQ1NzhlYjkiLCJlbWFpbCI6InRlc3Q2QHRlc3QuY29tIiwibmFtZSI6InQ2IiwidXNlclR5cGUiOiJtb3ZlciIsImlhdCI6MTc1MjQ4MDU1MCwiZXhwIjoxNzUyNDg0MTUwfQ.JkXNM5-srq7PIAwqlyFhnClrk9Pbwuja63K3VLLR1Ok
 
 ### 기사님 프로필 등록
 POST http://localhost:4000/profile/mover
@@ -7,12 +6,12 @@ Content-Type: application/json
 Authorization: Bearer {{token}}
 
 {
-     "nickName": "tester8", 
+     "nickName": "tester6", 
      "career": 3, 
      "introduction":"abcdefghijklmnopqrstuvwxyz",  
      "description":"abcdefghijklmnopqrstuvwxyz" , 
      "serviceType":["소형이사", "사무실이사"],
-     "serviceArea": ["경기"]
+     "serviceArea": ["경기", "인천"]
 }
 
 ### 기사님 프로필 수정
@@ -21,7 +20,7 @@ Content-Type: application/json
 Authorization: Bearer {{token}}
 
 {
-     "nickName": "tester8", 
+     "nickName": "tester6-1", 
      "career": 7, 
      "introduction":"abcdefghijklmnopqrstuvwxyz",  
      "description":"abcdefghijklmnopqrstuvwxyz" , 

--- a/http/profile.http
+++ b/http/profile.http
@@ -1,13 +1,28 @@
-# @token={{$dotenv TOKEN}}
+@token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJlZGFkMDM0Mi1lODI4LTRjNTItOWIzMy0xYTkzOGQ5Mzk5NGMiLCJlbWFpbCI6InRlc3Q4QHRlc3QuY29tIiwibmFtZSI6InQ4IiwidXNlclR5cGUiOiJtb3ZlciIsImlhdCI6MTc1MjQ3OTE2MSwiZXhwIjoxNzUyNDgyNzYxfQ.JArjBSy-xzqdjV_A6mDW24V9LDfTzBpIwewyvBR-T4s
+
 
 ### 기사님 프로필 등록
 POST http://localhost:4000/profile/mover
 Content-Type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI3NzNmOTI2NC1hMGVkLTQxMzItYTQzNC04MzcwZDQ1NzhlYjkiLCJlbWFpbCI6InRlc3Q2QHRlc3QuY29tIiwibmFtZSI6InQ2IiwidXNlclR5cGUiOiJtb3ZlciIsImlhdCI6MTc1MjQ3MjEyNSwiZXhwIjoxNzUyNDc1NzI1fQ.c4i_pD0mj2b73QcXkv085NsPAd4rHVqdkWeIkLzh9r4
+Authorization: Bearer {{token}}
 
 {
-     "nickName": "tester1", 
+     "nickName": "tester8", 
      "career": 3, 
+     "introduction":"abcdefghijklmnopqrstuvwxyz",  
+     "description":"abcdefghijklmnopqrstuvwxyz" , 
+     "serviceType":["소형이사", "사무실이사"],
+     "serviceArea": ["경기"]
+}
+
+### 기사님 프로필 수정
+PATCH  http://localhost:4000/profile/mover
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+     "nickName": "tester8", 
+     "career": 7, 
      "introduction":"abcdefghijklmnopqrstuvwxyz",  
      "description":"abcdefghijklmnopqrstuvwxyz" , 
      "serviceType":["소형이사", "사무실이사"],

--- a/http/profile.http
+++ b/http/profile.http
@@ -1,5 +1,9 @@
+@token={{$dotenv TOKEN}}
+
 ### 기사님 프로필 등록
 POST http://localhost:3000/profile/movers
+Content-Type: application/json
+Authorization: Bearer {{token}}
 
 {
      "image": , 

--- a/http/profile.http
+++ b/http/profile.http
@@ -1,16 +1,15 @@
 # @token={{$dotenv TOKEN}}
 
 ### 기사님 프로필 등록
-POST http://localhost:3000/profile/1/mover
+POST http://localhost:4000/profile/mover
 Content-Type: application/json
-Authorization: Bearer 
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiI3NzNmOTI2NC1hMGVkLTQxMzItYTQzNC04MzcwZDQ1NzhlYjkiLCJlbWFpbCI6InRlc3Q2QHRlc3QuY29tIiwibmFtZSI6InQ2IiwidXNlclR5cGUiOiJtb3ZlciIsImlhdCI6MTc1MjQ3MjEyNSwiZXhwIjoxNzUyNDc1NzI1fQ.c4i_pD0mj2b73QcXkv085NsPAd4rHVqdkWeIkLzh9r4
 
 {
-     "image": , 
      "nickName": "tester1", 
-     "career": "3", 
+     "career": 3, 
      "introduction":"abcdefghijklmnopqrstuvwxyz",  
      "description":"abcdefghijklmnopqrstuvwxyz" , 
      "serviceType":["소형이사", "사무실이사"],
-     "region": ["경기"]
+     "serviceArea": ["경기"]
 }

--- a/src/constants/ErrorMessage.ts
+++ b/src/constants/ErrorMessage.ts
@@ -9,6 +9,7 @@ export const ErrorMessage = {
   // Not Match
   PASSWORD_NOT_MATCH: "비밀번호가 일치하지 않습니다.",
   PASSWORD_CONFIRMATION_NOT_MATCH: "비밀번호 확인 결과가 일치하지 않습니다.",
+  PROFILE_NOT_MATCH: "등록된 프로필이 없습니다.",
 
   // Already Exist
   ALREADY_EXIST_EMAIL: "이미 사용 중인 이메일입니다.",

--- a/src/constants/ErrorMessage.ts
+++ b/src/constants/ErrorMessage.ts
@@ -14,6 +14,7 @@ export const ErrorMessage = {
   ALREADY_EXIST_EMAIL: "이미 사용 중인 이메일입니다.",
   ALREADY_EXIST_NICKNAME: "이미 사용 중인 닉네임입니다.",
   ALREADY_EXIST_PHONE: "이미 사용 중인 전화번호입니다.",
+  ALREADY_EXIST_PROFILE: "이미 프로필이 존재합니다. 프로필 수정을 이용해주세요",
 
   // Invalid
   INVALID_EMAIL: "잘못된 이메일입니다.",

--- a/src/controllers/authMover.controller.ts
+++ b/src/controllers/authMover.controller.ts
@@ -10,7 +10,6 @@ import { NextFunction, Request, Response } from "express";
 import authService from "../services/authMover.service";
 import { MoverSigninDto, MoverSignupDto, signUpMoverSchema } from "../dtos/auth/authMover.dto";
 import { BadRequestError } from "../types/errors";
-import { ErrorMessage } from "../constants/ErrorMessage";
 
 //기사님 회원가입
 async function moverSingup(
@@ -34,7 +33,7 @@ async function moverSingup(
       phone,
       password,
     });
-    res.status(201).json({ mover: mover });
+    res.status(201).json(mover);
   } catch (error) {
     next(error);
   }
@@ -53,7 +52,7 @@ async function moverSignin(
       email,
       password,
     });
-    res.status(200).json({ mover: mover });
+    res.status(200).json(mover);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/authMover.controller.ts
+++ b/src/controllers/authMover.controller.ts
@@ -34,7 +34,7 @@ async function moverSingup(
       phone,
       password,
     });
-    res.status(200).json({ mover: mover });
+    res.status(201).json({ mover: mover });
   } catch (error) {
     next(error);
   }
@@ -53,7 +53,7 @@ async function moverSignin(
       email,
       password,
     });
-    res.status(201).json({ mover: mover });
+    res.status(200).json({ mover: mover });
   } catch (error) {
     next(error);
   }

--- a/src/controllers/profileMover.controller.ts
+++ b/src/controllers/profileMover.controller.ts
@@ -6,10 +6,11 @@
 
 import { NextFunction, Request, Response } from "express";
 import profileMoverService from "../services/profileMover.service";
-import { MoverProfile } from "../dtos/profile.dto";
+import { MoverProfileDto } from "../dtos/profile.dto";
 
+//기사님 프로필 생성 (=기사님 모델 정보 추가)
 async function moverCreateProfile(
-  req: Request<{}, {}, MoverProfile>,
+  req: Request<{}, {}, MoverProfileDto>,
   res: Response,
   next: NextFunction,
 ) {
@@ -28,27 +29,40 @@ async function moverCreateProfile(
       serviceType,
       serviceArea,
     });
-    res.status(201).json({ user });
+    res.status(201).json(user);
   } catch (error) {
     next(error);
   }
 }
 
-// async function moverPatchProfile(
-//   req: Request<{}, {}, { email: string; password: string }>,
-//   res: Response,
-//   next: NextFunction,
-// ) {
-//   const { userId } = req.auth;
-//   const { image, name, career, introduction, description, serviceType } = req.body;
-//   try {
-//     const user = await profileService.pathchMover(userId, email, password);
-//     res.status(201).json({ user });
-//   } catch (error) {
-//     next(error);
-//   }
-// }
+//기사님 프로필 수정(=기사님 모델 정보 수정)
+async function moverPatchProfile(
+  req: Request<{}, {}, MoverProfileDto>,
+  res: Response,
+  next: NextFunction,
+) {
+  const { userId } = req.auth!;
+  const { email, image, nickName, career, introduction, description, serviceType, serviceArea } =
+    req.body;
+  try {
+    const user = await profileMoverService.patchMoverProfile({
+      userId,
+      email,
+      image,
+      nickName,
+      career,
+      introduction,
+      description,
+      serviceType,
+      serviceArea,
+    });
+    res.status(200).json(user);
+  } catch (error) {
+    next(error);
+  }
+}
 
 export default {
   moverCreateProfile,
+  moverPatchProfile,
 };

--- a/src/controllers/profileMover.controller.ts
+++ b/src/controllers/profileMover.controller.ts
@@ -2,22 +2,41 @@
  * @file profile.controller.ts
  * @description
  * - 프로필 관련 HTTP 요청을 처리하는 컨트롤러
- * - named export 사용
- *
  */
 
 import { NextFunction, Request, Response } from "express";
 
-export async function moverPatchProfile(
-    req: Request<{}, {}, { email: string; password: string }>,
-    res: Response,
-    next: NextFunction,
+async function moverCreateProfile(
+  req: Request<{}, {}, { email: string; password: string }>,
+  res: Response,
+  next: NextFunction,
 ) {
-    // const { image, name, career, introduction, description, serviceType } = req.body;
-    // try {
-    //     const user = await profileService.createUser(email, password);
-    //     res.status(201).json({ user });
-    // } catch (error) {
-    //     next(error);
-    // }
+  const { userId } = req.auth;
+  const { image, name, career, introduction, description, serviceType } = req.body;
+  try {
+    const user = await profileService.createMover(userId, email, password);
+    res.status(201).json({ user });
+  } catch (error) {
+    next(error);
+  }
 }
+
+async function moverPatchProfile(
+  req: Request<{}, {}, { email: string; password: string }>,
+  res: Response,
+  next: NextFunction,
+) {
+  const { userId } = req.auth;
+  const { image, name, career, introduction, description, serviceType } = req.body;
+  try {
+    const user = await profileService.pathchMover(userId, email, password);
+    res.status(201).json({ user });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export default {
+  moverCreateProfile,
+  moverPatchProfile,
+};

--- a/src/controllers/profileMover.controller.ts
+++ b/src/controllers/profileMover.controller.ts
@@ -7,6 +7,8 @@
 import { NextFunction, Request, Response } from "express";
 import profileMoverService from "../services/profileMover.service";
 import { MoverProfileDto } from "../dtos/profile.dto";
+import { filterSensitiveUserData } from "../utils/auth.util";
+import { create } from "domain";
 
 //기사님 프로필 생성 (=기사님 모델 정보 추가)
 async function moverCreateProfile(
@@ -18,7 +20,7 @@ async function moverCreateProfile(
   const { email, image, nickName, career, introduction, description, serviceType, serviceArea } =
     req.body;
   try {
-    const user = await profileMoverService.createMoverProfile({
+    const createdMoverProfile = await profileMoverService.createMoverProfile({
       userId,
       email,
       image,
@@ -29,7 +31,9 @@ async function moverCreateProfile(
       serviceType,
       serviceArea,
     });
-    res.status(201).json(user);
+
+    const filteredMoverProfile = filterSensitiveUserData(createdMoverProfile);
+    res.status(201).json(filteredMoverProfile);
   } catch (error) {
     next(error);
   }
@@ -45,7 +49,7 @@ async function moverPatchProfile(
   const { email, image, nickName, career, introduction, description, serviceType, serviceArea } =
     req.body;
   try {
-    const user = await profileMoverService.patchMoverProfile({
+    const updatedMoverProfile = await profileMoverService.patchMoverProfile({
       userId,
       email,
       image,
@@ -56,7 +60,9 @@ async function moverPatchProfile(
       serviceType,
       serviceArea,
     });
-    res.status(200).json(user);
+
+    const filteredMoverProfile = filterSensitiveUserData(updatedMoverProfile);
+    res.status(200).json(filteredMoverProfile);
   } catch (error) {
     next(error);
   }

--- a/src/controllers/profileMover.controller.ts
+++ b/src/controllers/profileMover.controller.ts
@@ -5,38 +5,50 @@
  */
 
 import { NextFunction, Request, Response } from "express";
+import profileMoverService from "../services/profileMover.service";
+import { MoverProfile } from "../dtos/profile.dto";
 
 async function moverCreateProfile(
-  req: Request<{}, {}, { email: string; password: string }>,
+  req: Request<{}, {}, MoverProfile>,
   res: Response,
   next: NextFunction,
 ) {
-  const { userId } = req.auth;
-  const { image, name, career, introduction, description, serviceType } = req.body;
+  const { userId } = req.auth!;
+  const { email, image, nickName, career, introduction, description, serviceType, serviceArea } =
+    req.body;
   try {
-    const user = await profileService.createMover(userId, email, password);
+    const user = await profileMoverService.createMoverProfile({
+      userId,
+      email,
+      image,
+      nickName,
+      career,
+      introduction,
+      description,
+      serviceType,
+      serviceArea,
+    });
     res.status(201).json({ user });
   } catch (error) {
     next(error);
   }
 }
 
-async function moverPatchProfile(
-  req: Request<{}, {}, { email: string; password: string }>,
-  res: Response,
-  next: NextFunction,
-) {
-  const { userId } = req.auth;
-  const { image, name, career, introduction, description, serviceType } = req.body;
-  try {
-    const user = await profileService.pathchMover(userId, email, password);
-    res.status(201).json({ user });
-  } catch (error) {
-    next(error);
-  }
-}
+// async function moverPatchProfile(
+//   req: Request<{}, {}, { email: string; password: string }>,
+//   res: Response,
+//   next: NextFunction,
+// ) {
+//   const { userId } = req.auth;
+//   const { image, name, career, introduction, description, serviceType } = req.body;
+//   try {
+//     const user = await profileService.pathchMover(userId, email, password);
+//     res.status(201).json({ user });
+//   } catch (error) {
+//     next(error);
+//   }
+// }
 
 export default {
   moverCreateProfile,
-  moverPatchProfile,
 };

--- a/src/dtos/auth/authMover.dto.ts
+++ b/src/dtos/auth/authMover.dto.ts
@@ -1,12 +1,12 @@
 import z from "zod";
-import { createMoverInput, getMoverInput } from "../../types";
+import { CreateMoverInput, GetMoverInput } from "../../types";
 import { ErrorMessage } from "../../constants/ErrorMessage";
 
 //기사님 회원가입 DTO
-export interface MoverSignupDto extends createMoverInput {}
+export interface MoverSignupDto extends CreateMoverInput {}
 
 //기사님 로그인 DTO
-export interface MoverSigninDto extends getMoverInput {}
+export interface MoverSigninDto extends GetMoverInput {}
 
 //기사님 회원가입 유효성 검사
 export const signUpMoverSchema = z

--- a/src/dtos/profile.dto.ts
+++ b/src/dtos/profile.dto.ts
@@ -1,4 +1,4 @@
-import { CreateMoverProfile } from "../types";
+import { MoverProfile } from "../types";
 
 //기사님 프로필 등록/수정
-export interface MoverProfile extends CreateMoverProfile {}
+export interface MoverProfileDto extends MoverProfile {}

--- a/src/dtos/profile.dto.ts
+++ b/src/dtos/profile.dto.ts
@@ -1,0 +1,4 @@
+import { CreateMoverProfile } from "../types";
+
+//기사님 프로필 등록/수정
+export interface MoverProfile extends CreateMoverProfile {}

--- a/src/repositories/authMover.repository.ts
+++ b/src/repositories/authMover.repository.ts
@@ -12,46 +12,46 @@
 
 import { Mover } from "@prisma/client";
 import prisma from "../configs/prisma.config";
-import { createMoverInputwithHash } from "../types/mover/auth/authMover.type";
+import { CreateMoverInputwithHash } from "../types";
 
 //기사님 생성
-async function saveMover(user: createMoverInputwithHash) {
-    const createdMover = await prisma.mover.create({
-        data: {
-            name: user.name,
-            email: user.email,
-            phone: user.phone,
-            hashedPassword: user.hashedPassword,
-        },
-    });
+async function saveMover(user: CreateMoverInputwithHash) {
+  const createdMover = await prisma.mover.create({
+    data: {
+      name: user.name,
+      email: user.email,
+      phone: user.phone,
+      hashedPassword: user.hashedPassword,
+    },
+  });
 
-    return { ...createdMover, userType: "mover" }; //userType은 FE의 header에서 필요
+  return { ...createdMover, userType: "mover" }; //userType은 FE의 header에서 필요
 }
 
 //이메일로 기사님 조회
 async function findMoverByEmail(email: Mover["email"]) {
-    const mover = await prisma.mover.findUnique({
-        where: {
-            email,
-        },
-    });
+  const mover = await prisma.mover.findUnique({
+    where: {
+      email,
+    },
+  });
 
-    if (!mover) return null;
+  if (!mover) return null;
 
-    return { ...mover, userType: "mover" }; //userType은 FE의 header에서 필요
+  return { ...mover, userType: "mover" }; //userType은 FE의 header에서 필요
 }
 
 //전화번호로 기사님 조회
 async function findMoverByPhone(phone: Mover["phone"]) {
-    return await prisma.mover.findUnique({
-        where: {
-            phone,
-        },
-    });
+  return await prisma.mover.findUnique({
+    where: {
+      phone,
+    },
+  });
 }
 
 export default {
-    saveMover,
-    findMoverByEmail,
-    findMoverByPhone,
+  saveMover,
+  findMoverByEmail,
+  findMoverByPhone,
 };

--- a/src/repositories/authMover.repository.ts
+++ b/src/repositories/authMover.repository.ts
@@ -25,7 +25,7 @@ async function saveMover(user: CreateMoverInputwithHash) {
     },
   });
 
-  return { ...createdMover, userType: "mover" }; //userType은 FE의 header에서 필요
+  return { ...createdMover, userType: "mover", profileCompleted: false }; //userType은 FE의 header에서 필요
 }
 
 //이메일로 기사님 조회
@@ -38,7 +38,7 @@ async function findMoverByEmail(email: Mover["email"]) {
 
   if (!mover) return null;
 
-  return { ...mover, userType: "mover" }; //userType은 FE의 header에서 필요
+  return { ...mover, userType: "mover", profileCompleted: false }; //userType은 FE의 header에서 필요
 }
 
 //전화번호로 기사님 조회

--- a/src/repositories/profileMover.respository.ts
+++ b/src/repositories/profileMover.respository.ts
@@ -9,31 +9,62 @@ import { ErrorMessage } from "../constants/ErrorMessage";
 import { NotFoundError } from "../types/errors";
 import { createMoverProfile } from "../types/mover/auth/authMover.type";
 
-//기사님 프로필 생성
+
+// //기사님 프로필 생성
+// async function createMoverProfile(user: createMoverProfile) {
+//     const existedMover = await prisma.mover.findUnique({
+//         where: { email: user.email },
+//     });
+
+//     if (existedMover) {
+//        throw new 
+//       };
+
+//       const createdMoverProfile = await prisma.mover.update({
+//         where:{email: user.email},
+//         data: {
+//           image: user.image,
+//           nickName: user.nickName,
+//           career: user.career,
+//           introduction: user.introduction,
+//           description: user.description,
+//           serviceType: user.serviceType,
+//             // region
+//         },
+//     )
+//         return { ...createdMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
+//     } else {
+//       throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
+//     }
+// }
+
+//기사님 프로필 등록
 async function saveMoverProfile(user: createMoverProfile) {
     const existedMover = await prisma.mover.findUnique({
-        where: { email: user.email },
+        where: { id: user.userId },
     });
 
-    //todo
-    // if (existedMover) {
-    //    const createdMoverProfile = await prisma.mover.update({
-    //     where:{email: user.email},
-    //     data: {
-    //       image: user.image,
-    //       nickName: user.nickName,
-    //       career: user.career,
-    //       introduction: user.introduction,
-    //       description: user.description,
-    //       serviceType: user.serviceType,
-    //         // region
-    //     },
-    //   });
+    //회원가입 기사님만 프로필 등록 가능
+    if (!existedMover) { 
+     throw new NotFoundError(ErrorMessage.USER_NOT_FOUND)
+      };
 
-    //     return { ...createdMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
-    // } else {
-    //   throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
-    // }
+        const createdMoverProfile = await prisma.mover.update({
+        where:{email: user.userId},
+        data: {
+          image: user.image,
+          nickName: user.nickName,
+          career: user.career,
+          introduction: user.introduction,
+          description: user.description,
+          serviceType: user.serviceType,
+            // region
+        },
+    )
+        return { ...createdMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
+    } else {
+      throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
+    }
 }
 
 export default {

--- a/src/repositories/profileMover.respository.ts
+++ b/src/repositories/profileMover.respository.ts
@@ -6,67 +6,43 @@
 
 import prisma from "../configs/prisma.config";
 import { ErrorMessage } from "../constants/ErrorMessage";
-import { NotFoundError } from "../types/errors";
-import { createMoverProfile } from "../types/mover/auth/authMover.type";
+import { BadRequestError, NotFoundError } from "../types/errors";
+import { CreateMoverProfile } from "../types";
 
+//기사님 프로필 등록/수정
+async function saveMoverProfile(user: CreateMoverProfile) {
+  const existedMover = await prisma.mover.findUnique({
+    where: { id: user.userId },
+  });
 
-// //기사님 프로필 생성
-// async function createMoverProfile(user: createMoverProfile) {
-//     const existedMover = await prisma.mover.findUnique({
-//         where: { email: user.email },
-//     });
+  //회원가입 기사님만 프로필 등록 가능
+  if (!existedMover) {
+    throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
+  } else if (existedMover.nickName) {
+    throw new BadRequestError(ErrorMessage.ALREADY_EXIST_PROFILE);
+  }
 
-//     if (existedMover) {
-//        throw new 
-//       };
+  //존재하는 기사님의 프로필 등록(=첫 수정)
+  const createdMoverProfile = await prisma.mover.update({
+    where: { id: user.userId },
+    data: {
+      profileImage: user.image,
+      nickName: user.nickName,
+      career: user.career,
+      introduction: user.introduction,
+      description: user.description,
+      serviceType: {
+        set: user.serviceType, // enum 배열이라 set 사용
+      },
+      serviceArea: {
+        set: user.serviceArea.map((regionName) => ({ regionName })),
+      },
+    },
+  });
 
-//       const createdMoverProfile = await prisma.mover.update({
-//         where:{email: user.email},
-//         data: {
-//           image: user.image,
-//           nickName: user.nickName,
-//           career: user.career,
-//           introduction: user.introduction,
-//           description: user.description,
-//           serviceType: user.serviceType,
-//             // region
-//         },
-//     )
-//         return { ...createdMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
-//     } else {
-//       throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
-//     }
-// }
-
-//기사님 프로필 등록
-async function saveMoverProfile(user: createMoverProfile) {
-    const existedMover = await prisma.mover.findUnique({
-        where: { id: user.userId },
-    });
-
-    //회원가입 기사님만 프로필 등록 가능
-    if (!existedMover) { 
-     throw new NotFoundError(ErrorMessage.USER_NOT_FOUND)
-      };
-
-        const createdMoverProfile = await prisma.mover.update({
-        where:{email: user.userId},
-        data: {
-          image: user.image,
-          nickName: user.nickName,
-          career: user.career,
-          introduction: user.introduction,
-          description: user.description,
-          serviceType: user.serviceType,
-            // region
-        },
-    )
-        return { ...createdMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
-    } else {
-      throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
-    }
+  return { ...createdMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
 }
 
 export default {
-    saveMoverProfile,
+  saveMoverProfile,
 };

--- a/src/repositories/profileMover.respository.ts
+++ b/src/repositories/profileMover.respository.ts
@@ -6,11 +6,11 @@
 
 import prisma from "../configs/prisma.config";
 import { ErrorMessage } from "../constants/ErrorMessage";
+import { MoverProfile } from "../types";
 import { BadRequestError, NotFoundError } from "../types/errors";
-import { CreateMoverProfile } from "../types";
 
-//기사님 프로필 등록/수정
-async function saveMoverProfile(user: CreateMoverProfile) {
+//기사님 프로필 등록
+async function saveMoverProfile(user: MoverProfile) {
   const existedMover = await prisma.mover.findUnique({
     where: { id: user.userId },
   });
@@ -20,6 +20,16 @@ async function saveMoverProfile(user: CreateMoverProfile) {
     throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
   } else if (existedMover.nickName) {
     throw new BadRequestError(ErrorMessage.ALREADY_EXIST_PROFILE);
+  }
+
+  //닉네임은 unique 속성이라서
+  const existedNickName = await prisma.mover.findUnique({
+    where: {
+      nickName: user.nickName,
+    },
+  });
+  if (existedNickName) {
+    throw new BadRequestError(ErrorMessage.ALREADY_EXIST_NICKNAME);
   }
 
   //존재하는 기사님의 프로필 등록(=첫 수정)
@@ -40,9 +50,57 @@ async function saveMoverProfile(user: CreateMoverProfile) {
     },
   });
 
-  return { ...createdMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
+  return { ...createdMoverProfile, userType: "mover", profileCompleted: true }; //userType은 FE의 header에서 필요, profilCompleted는 프론트 라우터에서 필요
+}
+
+//기사님 프로필 수정
+async function patchMoverProfile(user: MoverProfile) {
+  const existedMover = await prisma.mover.findUnique({
+    where: { id: user.userId },
+  });
+
+  //회원가입 && 프로필 존재하는 기사님만 수정 가능
+  if (!existedMover) {
+    throw new NotFoundError(ErrorMessage.USER_NOT_FOUND);
+  } else if (!existedMover.nickName) {
+    throw new BadRequestError(ErrorMessage.PROFILE_NOT_MATCH);
+  }
+
+  //닉네임은 unique 속성 + 기존의 내 닉네임은 제외
+  const existedNickName = await prisma.mover.findFirst({
+    where: {
+      nickName: user.nickName,
+      NOT: {
+        id: user.userId,
+      },
+    },
+  });
+  if (existedNickName) {
+    throw new BadRequestError(ErrorMessage.ALREADY_EXIST_NICKNAME);
+  }
+
+  //존재하는 기사님의 프로필 수정
+  const patedMoverProfile = await prisma.mover.update({
+    where: { id: user.userId },
+    data: {
+      profileImage: user.image,
+      nickName: user.nickName,
+      career: user.career,
+      introduction: user.introduction,
+      description: user.description,
+      serviceType: {
+        set: user.serviceType, // enum 배열이라 set 사용
+      },
+      serviceArea: {
+        set: user.serviceArea.map((regionName) => ({ regionName })),
+      },
+    },
+  });
+
+  return { ...patedMoverProfile, userType: "mover" }; //userType은 FE의 header에서 필요
 }
 
 export default {
   saveMoverProfile,
+  patchMoverProfile,
 };

--- a/src/routers/profile.router.ts
+++ b/src/routers/profile.router.ts
@@ -11,8 +11,8 @@ const profileRouter = express.Router();
 //기사님 프로필 등록
 profileRouter.post("/mover", profileMoverController.moverCreateProfile);
 
-// //기사님 프로필 수정
-// profileRouter.patch("/:profileId/mover", profileMoverController.moverPatchProfile);
+//기사님 프로필 수정
+profileRouter.patch("/mover", profileMoverController.moverPatchProfile);
 
 //todo:일반 유저 프로필 등록과 수정
 

--- a/src/routers/profile.router.ts
+++ b/src/routers/profile.router.ts
@@ -11,8 +11,8 @@ const profileRouter = express.Router();
 //기사님 프로필 등록
 profileRouter.post("/mover", profileMoverController.moverCreateProfile);
 
-//기사님 프로필 수정
-profileRouter.patch("/:profileId/mover", profileMoverController.moverPatchProfile);
+// //기사님 프로필 수정
+// profileRouter.patch("/:profileId/mover", profileMoverController.moverPatchProfile);
 
 //todo:일반 유저 프로필 등록과 수정
 

--- a/src/routers/profile.router.ts
+++ b/src/routers/profile.router.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import profileMoverController from "../controllers/profileMover.controller";
 
 const profileRouter = express.Router();
 
@@ -7,8 +8,11 @@ const profileRouter = express.Router();
  * @description 프로필 관련 라우트 정의 모듈 (프로필 등록, 프로필 수정 등)
  */
 
-// //기사님 프로필 등록과 수정
-// profileRouter.patch("/mover", authMi, moverPatchProfile);
+//기사님 프로필 등록
+profileRouter.post("/mover", profileMoverController.moverCreateProfile);
+
+//기사님 프로필 수정
+profileRouter.patch("/:profileId/mover", profileMoverController.moverPatchProfile);
 
 //todo:일반 유저 프로필 등록과 수정
 

--- a/src/services/authMover.service.ts
+++ b/src/services/authMover.service.ts
@@ -9,13 +9,13 @@
 import authRepository from "../repositories/authMover.repository";
 import { ConflictError, NotFoundError, UnauthorizedError } from "../types/errors";
 import { ErrorMessage } from "../constants/ErrorMessage";
-import { createMoverInput, getMoverInput } from "../types/mover/auth/authMover.type";
 import { hashPassword } from "../utils/auth.util";
 import { generateAccessToken, generateRefreshToken } from "../utils/token.util";
 import bcrypt from "bcrypt";
+import { CreateMoverInput, GetMoverInput } from "../types";
 
 //기사님 생성
-async function createMover(user: createMoverInput) {
+async function createMover(user: CreateMoverInput) {
   const existedEmail = await authRepository.findMoverByEmail(user.email);
   if (existedEmail) {
     throw new ConflictError(ErrorMessage.ALREADY_EXIST_EMAIL);
@@ -57,7 +57,7 @@ async function createMover(user: createMoverInput) {
 }
 
 //기사님 조회(로그인)
-async function getMoverByEmail(user: getMoverInput) {
+async function getMoverByEmail(user: GetMoverInput) {
   //사용자 조회
   const mover = await authRepository.findMoverByEmail(user.email);
   if (!mover) {

--- a/src/services/authMover.service.ts
+++ b/src/services/authMover.service.ts
@@ -47,12 +47,11 @@ async function createMover(user: CreateMoverInput) {
   return {
     accessToken,
     refreshToken,
-    user: {
-      userId: createdMover.id,
-      email: createdMover.email,
-      nickName: createdMover.nickName,
-      userType: createdMover.userType,
-    },
+    userId: createdMover.id,
+    email: createdMover.email,
+    nickName: createdMover.nickName,
+    userType: createdMover.userType,
+    profileCompleted: createdMover.profileCompleted,
   };
 }
 
@@ -85,14 +84,13 @@ async function getMoverByEmail(user: GetMoverInput) {
   });
 
   return {
-    user: {
-      userId: mover.id,
-      email: mover.email,
-      nickName: mover.nickName,
-      userType: mover.userType,
-    },
     accessToken,
     refreshToken,
+    userId: mover.id,
+    email: mover.email,
+    nickName: mover.nickName,
+    userType: mover.userType,
+    profileCompleted: mover.profileCompleted,
   };
 }
 

--- a/src/services/profileMover.service.ts
+++ b/src/services/profileMover.service.ts
@@ -6,18 +6,31 @@
  *
  */
 
-import { moverSignin } from "../controllers/authMover.controller";
-import profileRespository from "../repositories/profileMover.respository";
-import { CreateMoverProfile } from "../types";
+import profileMoverRespository from "../repositories/profileMover.respository";
+import { MoverProfile } from "../types";
 import { serviceTypeMap } from "../utils/dataMapper.util";
 
-//기사님 프로필 생성/수정
-async function createMoverProfile(user: CreateMoverProfile) {
+//기사님 프로필 생성
+async function createMoverProfile(user: MoverProfile) {
   //serviceType 데이터 맞추기
   const mappedServiceType = user.serviceType.map((label) => serviceTypeMap[label]);
-  return await profileRespository.saveMoverProfile({ ...user, serviceType: mappedServiceType });
+  return await profileMoverRespository.saveMoverProfile({
+    ...user,
+    serviceType: mappedServiceType,
+  });
+}
+
+//기사님 프로필 수정
+async function patchMoverProfile(user: MoverProfile) {
+  //serviceType 데이터 맞추기
+  const mappedServiceType = user.serviceType.map((label) => serviceTypeMap[label]);
+  return await profileMoverRespository.patchMoverProfile({
+    ...user,
+    serviceType: mappedServiceType,
+  });
 }
 
 export default {
   createMoverProfile,
+  patchMoverProfile,
 };

--- a/src/services/profileMover.service.ts
+++ b/src/services/profileMover.service.ts
@@ -6,14 +6,18 @@
  *
  */
 
-import { createMoverProfile } from "../types/mover/auth/authMover.type";
+import { moverSignin } from "../controllers/authMover.controller";
 import profileRespository from "../repositories/profileMover.respository";
+import { CreateMoverProfile } from "../types";
+import { serviceTypeMap } from "../utils/dataMapper.util";
 
-//기사님 프로필 생성
-async function createMoverProfile(user: createMoverProfile) {
-    return await profileRespository.saveMoverProfile(user);
+//기사님 프로필 생성/수정
+async function createMoverProfile(user: CreateMoverProfile) {
+  //serviceType 데이터 맞추기
+  const mappedServiceType = user.serviceType.map((label) => serviceTypeMap[label]);
+  return await profileRespository.saveMoverProfile({ ...user, serviceType: mappedServiceType });
 }
 
 export default {
-    createMoverProfile,
+  createMoverProfile,
 };

--- a/src/types/authMover.types.ts
+++ b/src/types/authMover.types.ts
@@ -1,7 +1,7 @@
 import { MoveType } from "@prisma/client";
 
 //기사님 회원가입할 때 필요한 값 (컨트롤러, 서비스 단)
-export type createMoverInput = {
+export type CreateMoverInput = {
   name: string;
   email: string;
   phone: string;
@@ -9,7 +9,7 @@ export type createMoverInput = {
 };
 
 //기사님 회원가입할 때 필요한 값 (레포지토리 단)
-export type createMoverInputwithHash = {
+export type CreateMoverInputwithHash = {
   name: string;
   email: string;
   phone: string;
@@ -18,13 +18,13 @@ export type createMoverInputwithHash = {
 };
 
 //기사님 로그인할 때 필요한 값 (컨트롤러, 서비스 단)
-export type getMoverInput = {
+export type GetMoverInput = {
   email: string;
   password: string;
 };
 
 //기사님 프로필 등록할 때 필요한 값 (레포지토리 단)
-export type createMoverProfile = {
+export type CreateMoverProfile = {
   userId: string;
   email: string;
   image: string;
@@ -33,5 +33,5 @@ export type createMoverProfile = {
   introduction: string;
   description: string;
   serviceType: MoveType[];
-  // region: string[];
+  serviceArea: string[];
 };

--- a/src/types/authMover.types.ts
+++ b/src/types/authMover.types.ts
@@ -22,16 +22,3 @@ export type GetMoverInput = {
   email: string;
   password: string;
 };
-
-//기사님 프로필 등록할 때 필요한 값 (레포지토리 단)
-export type CreateMoverProfile = {
-  userId: string;
-  email: string;
-  image: string;
-  nickName: string;
-  career: number;
-  introduction: string;
-  description: string;
-  serviceType: MoveType[];
-  serviceArea: string[];
-};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,3 +12,4 @@ export * from "./authMover.types";
 export * from "./token.type";
 export * from "./review";
 export * from "./authClient.types";
+export * from "./profile.types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,7 +8,7 @@
  * export * from "./service";
  */
 
-export * from "./mover/auth/authMover.type";
+export * from "./authMover.types";
 export * from "./token.type";
 export * from "./review";
 export * from "./authClient.types";

--- a/src/types/mover/auth/authMover.type.ts
+++ b/src/types/mover/auth/authMover.type.ts
@@ -1,3 +1,5 @@
+import { MoveType } from "@prisma/client";
+
 //기사님 회원가입할 때 필요한 값 (컨트롤러, 서비스 단)
 export type createMoverInput = {
   name: string;
@@ -23,12 +25,13 @@ export type getMoverInput = {
 
 //기사님 프로필 등록할 때 필요한 값 (레포지토리 단)
 export type createMoverProfile = {
+  userId: string;
   email: string;
   image: string;
   nickName: string;
-  career: string;
+  career: number;
   introduction: string;
   description: string;
-  serviceType: string[];
-  region: string[];
+  serviceType: MoveType[];
+  // region: string[];
 };

--- a/src/types/profile.types.ts
+++ b/src/types/profile.types.ts
@@ -1,0 +1,14 @@
+import { MoveType } from "@prisma/client";
+
+//기사님 프로필 등록할 때 필요한 값 (레포지토리 단)
+export type MoverProfile = {
+  userId: string;
+  email: string;
+  image: string;
+  nickName: string;
+  career: number;
+  introduction: string;
+  description: string;
+  serviceType: MoveType[];
+  serviceArea: string[];
+};

--- a/src/types/token.type.ts
+++ b/src/types/token.type.ts
@@ -1,7 +1,7 @@
 //토큰 생성 시 필요
-export type createdToken = {
-    userId: string;
-    email: string;
-    name: string;
-    userType: string;
+export type CreatedToken = {
+  userId: string;
+  email: string;
+  name: string;
+  userType: string;
 };

--- a/src/utils/dataMapper.util.ts
+++ b/src/utils/dataMapper.util.ts
@@ -1,0 +1,8 @@
+import { MoveType } from "@prisma/client";
+
+//ERD의 enum serviceType과 프론트의 key값을 mapping 해주기 위함
+export const serviceTypeMap: Record<string, MoveType> = {
+  소형이사: "SMALL",
+  가정이사: "HOME",
+  사무실이사: "OFFICE",
+};

--- a/src/utils/token.util.ts
+++ b/src/utils/token.util.ts
@@ -1,9 +1,9 @@
 import jwt from "jsonwebtoken";
 import { ConflictError } from "../types/errors";
 import { ErrorMessage } from "../constants/ErrorMessage";
-import { createdToken } from "../types";
+import { CreatedToken } from "../types";
 
-export function generateAccessToken(user: createdToken): string {
+export function generateAccessToken(user: CreatedToken): string {
   const payload = {
     userId: user.userId,
     email: user.email,
@@ -25,7 +25,7 @@ export function generateAccessToken(user: createdToken): string {
   return accessToken;
 }
 
-export function generateRefreshToken(user: createdToken): string {
+export function generateRefreshToken(user: CreatedToken): string {
   const payload = {
     userId: user.userId,
     email: user.email,


### PR DESCRIPTION
## 작업 개요
- 기사님 프로필 등록/수정 API 구현

---

## 작업 상세 내용
- [x] 기사님 프로필 등록 가능
- [x] 기사님 프로필 수정 가능 (등록이 선행되어야 함)
- [x] 스키마의 enum MoveType과 프론트 데이터 key 통일을 위한 mapper 유틸함수 작성
- [x] 레포지토리단에서 return 시 profileCompleted: false 필드 추가
- [x] 유저 개인정보 필터링 후 응답

---

## 🗂️ 수정한 파일
- `src/types/authMover.type.ts`

---

## 🗂️ 새로 작성한 파일
- `src/repositories/profileMover.repository.ts`
- `src/sevices/profileMover.sevice.ts`
- `src/controllers/profileMover.controller.ts`
- `src/dtos/profile.dto.ts`
- `src/utils/dataMapper.util.ts` (enum MoveType과 프론트 데이터 key 통일을 위한 mapper)

---

## 기타 참고 사항
