### PR TITLE
feat: request swagger api 설정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,9 +23,9 @@
         "multer-s3": "^3.0.1",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
-        "passport-jwt": "^4.0.1",
         "passport-kakao": "^1.0.1",
         "passport-naver": "^1.0.6",
+        "swagger-autogen": "^2.23.7",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "zod": "^3.25.76"
@@ -43,7 +43,6 @@
         "@types/node": "^24.0.10",
         "@types/passport": "^1.0.17",
         "@types/passport-google-oauth20": "^2.0.16",
-        "@types/passport-jwt": "^4.0.1",
         "@types/passport-kakao": "^1.0.3",
         "@types/passport-naver": "^1.0.4",
         "@types/swagger-jsdoc": "^6.0.4",
@@ -3831,17 +3830,6 @@
         "@types/passport-oauth2": "*"
       }
     },
-    "node_modules/@types/passport-jwt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
-      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/jsonwebtoken": "*",
-        "@types/passport-strategy": "*"
-      }
-    },
     "node_modules/@types/passport-kakao": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/passport-kakao/-/passport-kakao-1.0.3.tgz",
@@ -3873,17 +3861,6 @@
       "dependencies": {
         "@types/express": "*",
         "@types/oauth": "*",
-        "@types/passport": "*"
-      }
-    },
-    "node_modules/@types/passport-strategy": {
-      "version": "0.2.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
-      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
         "@types/passport": "*"
       }
     },
@@ -5087,7 +5064,6 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
       "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5846,7 +5822,6 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -7123,7 +7098,6 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -7847,16 +7821,6 @@
       },
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/passport-jwt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.1.tgz",
-      "integrity": "sha512-UCKMDYhNuGOBE9/9Ycuoyh7vP6jpeTp/+sfMJl7nLff/t6dps+iaeE0hhNkKN8/HZHcJ7lCdOyDxHdDoxoSvdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "jsonwebtoken": "^9.0.0",
-        "passport-strategy": "^1.0.0"
       }
     },
     "node_modules/passport-kakao": {
@@ -8803,6 +8767,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-autogen": {
+      "version": "2.23.7",
+      "resolved": "https://registry.npmjs.org/swagger-autogen/-/swagger-autogen-2.23.7.tgz",
+      "integrity": "sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^7.4.1",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.7",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/swagger-autogen/node_modules/acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/swagger-jsdoc": {

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
     "multer-s3": "^3.0.1",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
-    "passport-jwt": "^4.0.1",
     "passport-kakao": "^1.0.1",
     "passport-naver": "^1.0.6",
+    "swagger-autogen": "^2.23.7",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "zod": "^3.25.76"
@@ -50,7 +50,6 @@
     "@types/node": "^24.0.10",
     "@types/passport": "^1.0.17",
     "@types/passport-google-oauth20": "^2.0.16",
-    "@types/passport-jwt": "^4.0.1",
     "@types/passport-kakao": "^1.0.3",
     "@types/passport-naver": "^1.0.4",
     "@types/swagger-jsdoc": "^6.0.4",

--- a/src/swagger.ts
+++ b/src/swagger.ts
@@ -19,15 +19,10 @@ const options = {
         },
       },
     },
-    security: [
-      {
-        jwt: [],
-      },
-    ],
+    security: [],
     servers: [
       {
-        url: "localhost:3000",
-        describe: "local development server",
+        url: "/",
       },
     ],
   },

--- a/src/swagger/request.yaml
+++ b/src/swagger/request.yaml
@@ -1,0 +1,154 @@
+tags:
+  - name: Request
+    description: 견적 요청 관련 API
+
+paths:
+  /requests:
+    post:
+      tags:
+        - Request
+      summary: 견적 요청 생성
+      description: 일반 유저가 새로운 이사 견적 요청을 생성합니다.
+      security:
+        - jwt: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRequestDto"
+      responses:
+        "201":
+          description: 견적 요청 생성 완료
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Request"
+        "400":
+          description: 잘못된 요청
+        "401":
+          description: 인증 실패
+        "500":
+          description: 서버 오류
+
+    get:
+      tags:
+        - Request
+      summary: 받은 요청 목록 조회
+      description: 기사님이 자신에게 온 견적 요청 목록을 조회합니다.
+      security:
+        - jwt: []
+      parameters:
+        - name: moveType
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: isDesignated
+          in: query
+          required: false
+          schema:
+            type: boolean
+        - name: serviceArea
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: keyword
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [moveDate, requestedAt]
+        - name: cursor
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: 요청 목록 조회 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "받은 요청 조회 성공"
+                  totalCount:
+                    type: number
+                  nextCursor:
+                    type: string
+                    nullable: true
+                  requests:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Request"
+        "401":
+          description: 인증 실패
+        "500":
+          description: 서버 오류
+
+components:
+  schemas:
+    CreateRequestDto:
+      type: object
+      required:
+        - moveType
+        - moveDate
+        - fromAddress
+        - toAddress
+      properties:
+        moveType:
+          type: string
+          enum: [SMALL, HOME, OFFICE]
+        moveDate:
+          type: string
+          format: date
+        fromAddress:
+          type: string
+        toAddress:
+          type: string
+
+    Request:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        clientId:
+          type: string
+          format: uuid
+        moverId:
+          type: string
+          format: uuid
+          nullable: true
+        moveType:
+          type: string
+        moveDate:
+          type: string
+          format: date
+        fromAddress:
+          type: string
+        toAddress:
+          type: string
+        isPending:
+          type: boolean
+        requestedAt:
+          type: string
+          format: date-time
+        isDesignated:
+          type: boolean
+        clientName:
+          type: string


### PR DESCRIPTION
## 작업 개요
- Swagger에 견적 요청 관련 API 추가

<img width="711" height="464" alt="image" src="https://github.com/user-attachments/assets/e2bd5eb1-56b1-4790-93e9-ba621906e7b4" />


---

## 작업 상세 내용
- [x] 견적 요청 생성 API
- [x] 받은 요청 조회 API

---

## 🗂️ 수정한 파일
- `package.json`
  - `passport-jwt` 제거
  - `swagger-autogen` 추가(추후 미사용시 제거 예정)
- `swagger.ts` : 인증 필요한 라우터만 security 적용

---

## 🗂️ 새로 작성한 파일
- `request.yaml`

---

## 기타 참고 사항
- 현재 로컬 서버로 설정되어 있고, `Authorize`에 액세스 토큰 넣어서 테스트 할 수 있습니다.
- 다른 라우터들은 추후에 추가하겠습니다. (swagger 문서에 우선적으로 적용 필요한 부분 있으면 말씀해주세요.)
