### PR TITLE
feat: 기사님 기본정보 수정 API 연동

### DIFF
--- a/http/auth.http
+++ b/http/auth.http
@@ -17,8 +17,8 @@ POST http://localhost:4000/auth/signin/mover
 Content-Type: application/json
 
 {
-     "email": "MLocal22@test.com", 
-     "password": "a2222222"
+     "email": "MLocal4@test.com", 
+     "password": "a4444444"
 }
 
 ### 기사님 회원가입(배포주소)

--- a/src/services/accountMover.service.ts
+++ b/src/services/accountMover.service.ts
@@ -3,7 +3,7 @@ import accountMoverRepository from "../repositories/accountMover.repository";
 import authMoverRepository from "../repositories/authMover.repository";
 import { EditMoverAccount } from "../types/account.types";
 import { ConflictError } from "../types/errors";
-import { hashPassword, verifyPassword } from "../utils/auth.util";
+import { hashPassword } from "../utils/auth.util";
 import bcrypt from "bcrypt";
 
 //기사님 기본 정보 수정
@@ -43,7 +43,7 @@ async function patchMoverAccount(newData: EditMoverAccount) {
 
   //안 맞는 데이터 있으면 프론트로 에러 보내기
   if (Object.keys(fieldErrors).length > 0) {
-    throw new ConflictError("중복 정보로 인한 회원가입 실패: ", fieldErrors);
+    throw new ConflictError("DB와 대조 시 유효하지 않아서 실패: ", fieldErrors);
   }
 
   //프론트에서 받은 비밀번호 해시

--- a/src/services/profileMover.service.ts
+++ b/src/services/profileMover.service.ts
@@ -9,11 +9,11 @@
 import { createMoverProfile } from "../types/mover/auth/authMover.type";
 import profileRespository from "../repositories/profileMover.respository";
 
-//기사님 프로필 생성
-async function createMoverProfile(user: createMoverProfile) {
-    return await profileRespository.saveMoverProfile(user);
-}
+// //기사님 프로필 생성
+// async function createMoverProfile(user: createMoverProfile) {
+//     return await profileRespository.saveMoverProfile(user);
+// }
 
 export default {
-    createMoverProfile,
+  // createMoverProfile,
 };


### PR DESCRIPTION
## 작업 개요
- 기사님 기본정보 수정 API 연동

---

## 작업 상세 내용
- [x] 새 비밀번호 확인 변수명 checkNewPassword > newPasswordConfirmation 로 통일
- [x] 현재 내 비밀번호 검증하는 함수 추가 필요 (=본인확인)
- [x] 수정하려는 정보가 DB에 있는지 중복 확인 로직 구현
- [x] auth.controller.ts 부분에 성경님 주석 확인 > 적용함
- [x] 백엔드 에러 프론트로 연결하기

---

## 🗂️ 수정한 파일
src/services/accountMover.service.ts

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항

