### PR TITLE
refactor: 견적 컨트롤러 및 HTTP 요청 파일 리팩토링

### DIFF
--- a/http/estimate.http
+++ b/http/estimate.http
@@ -24,3 +24,26 @@ Accept: application/json
 GET http://localhost:4000/estimates/received
 Content-Type: application/json
 Authorization: Bearer {{token}}
+
+### 견적 요청 (기사 → 고객에게)
+POST http://localhost:4000/estimates/create
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "price": 150000,
+  "comment": "안녕하세요, 빠르고 안전하게 도와드리겠습니다.",
+  "clientId": "클라이언트_ID",
+  "requestId": "요청_ID"
+}
+
+### 견적 거절 (기사 → 고객 견적 거절)
+POST http://localhost:4000/estimates/reject
+Content-Type: application/json
+Authorization: Bearer {{token}}
+
+{
+  "comment": "죄송합니다. 일정이 맞지 않습니다.",
+  "clientId": "클라이언트_ID",
+  "requestId": "요청_ID"
+}

--- a/src/controllers/estimate.controller.ts
+++ b/src/controllers/estimate.controller.ts
@@ -42,11 +42,12 @@ async function sendEstimateToRequest(
   next: NextFunction,
 ): Promise<void> {
   try {
-    const { price, comment, moverId, clientId, requestId } = req.body;
+    const moverId = req.auth!.userId;
+    const { price, comment, clientId, requestId } = req.body;
 
-    if (!price || !comment || !moverId || !clientId || !requestId) {
+    if (!price || !comment || !clientId || !requestId) {
       res.status(400).json({
-        message: "price, comment, moverId, clientId, requestId는 모두 필수입니다.",
+        message: "price, comment, clientId, requestId는 모두 필수입니다.",
       });
       return;
     }
@@ -108,11 +109,13 @@ export async function getSentEstimateDetail(
 // 견적 거절하기
 async function rejectEstimate(req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    const { comment, moverId, clientId, requestId } = req.body;
+    const moverId = req.auth!.userId;
 
-    if (!comment || !moverId || !clientId || !requestId) {
+    const { comment, clientId, requestId } = req.body;
+
+    if (!comment || !clientId || !requestId) {
       res.status(400).json({
-        message: "comment, moverId, clientId, requestId는 모두 필수입니다.",
+        message: "comment,  clientId, requestId는 모두 필수입니다.",
       });
       return;
     }


### PR DESCRIPTION
## 작업 개요
- Postman 또는 .http 파일 기준 테스트 요청 정리
- 견적 요청 및 거절 API 관련 컨트롤러 로직 리팩토링

---

## 작업 상세 내용
- [x] estimate.http 요청 샘플 정리 및 테스트 시나리오 추가
- [x]  sendEstimateToRequest 및 rejectEstimate 컨트롤러 내부 조건 분기 구조 개선


---

## 🗂️ 수정한 파일
- `/http/estimate.http`
- `/src/controllers/estimate.controller.ts`




---

## 기타 참고 사항
- 추후 서비스 레이어 리팩토링 예정 시 의존 분리 고려
