### PR TITLE
fix: estimate 상세 조회 시 createdAt 누락 필드 추가

### DIFF
--- a/src/services/estimate.service.ts
+++ b/src/services/estimate.service.ts
@@ -146,6 +146,7 @@ async function findSentEstimateById(moverId: string, estimateId: string) {
       price: true,
       moverId: true,
       createdAt: true,
+      isClientConfirmed: true,
       request: {
         select: {
           moveType: true,

--- a/src/services/estimate.service.ts
+++ b/src/services/estimate.service.ts
@@ -145,6 +145,7 @@ async function findSentEstimateById(moverId: string, estimateId: string) {
       id: true,
       price: true,
       moverId: true,
+      createdAt: true,
       request: {
         select: {
           moveType: true,


### PR DESCRIPTION
## 작업 개요
- 백엔드 응답에서 createdAt 필드 누락되어 생긴 문제 해결

---

## 작업 상세 내용
- [x] findSentEstimateById 서비스 함수에서 createdAt 필드 선택(select) 추가



---

## 🗂️ 수정한 파일
- `src/services/estimate.service.ts`

---

## 기타 참고 사항
-관련 런타임 에러 로그: TypeError: Cannot read properties of undefined (reading 'slice')