### PR TITLE
fix:기사님 로그인 시 프로필 리다이렉트 로직 수정

### DIFF
--- a/src/services/authMover.service.ts
+++ b/src/services/authMover.service.ts
@@ -83,7 +83,7 @@ async function setMoverByEmail(user: GetMoverInput) {
     email: mover?.email,
     nickName: mover?.nickName,
     userType: mover?.userType,
-    // profileCompleted: mover?.profileCompleted,
+    isProfileCompleted: mover?.isProfileCompleted,
   };
 }
 


### PR DESCRIPTION
## 작업 개요
- 이슈 사항: 기사님 로그인 시 프로필 등록을 했음에도 로그아웃하고 다시 로그인 하면 프로필 없다고 함

---

## 작업 상세 내용
- [x] 기사님 로그인 시 프로필 리다이렉트 로직 수정

---

## 🗂️ 수정한 파일
- `src/services/profileMover.service.ts`

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항
