### PR TITLE
refactor: 받은 요청 필터링 조건 개선 및 응답 제외 조건 보완

### DIFF
--- a/src/types/request.type.ts
+++ b/src/types/request.type.ts
@@ -5,7 +5,7 @@ export interface GetReceivedRequestsQuery {
   serviceArea?: string;
   isDesignated?: string;
   keyword?: string;
-  sort?: "moveDate" | "requestedAt";
+  sort?: "moveDate-asc" | "moveDate-desc";
   limit?: string;
   cursor?: string;
   moverId: string;
@@ -16,7 +16,7 @@ export interface GetFilteredRequestsInput {
   serviceAreaList?: string[];
   isDesignated?: boolean;
   keyword?: string;
-  sort?: "moveDate" | "requestedAt";
+  sort?: "moveDate-asc" | "moveDate-desc";
   limit?: number;
   cursor?: string;
   moverId: string;


### PR DESCRIPTION
## 작업 개요
- 받은 요청 필터링 조건 개선 및 응답 제외 조건 보완

---

## 작업 상세 내용
- [x] 지정 견적 요청 ON/OFF 시 조건 분기 처리
- [x] 서비스 가능 지역 필터링 로직 적용 (mover.serviceArea 기준)
- [x] 이미 응답한 요청 및 확정된 요청 제외 (NOT 조건)
- [x] moveDate가 내일 이후인 요청만 필터링
- [x] keyword 검색 조건에 client.name 포함

---

## 🗂️ 수정한 파일
- `src/repositories/request.repository.ts`
- ` src/types/request.type.ts`

---

## 🗂️ 새로 작성한 파일
- 없음

---

## 기타 참고 사항
- 필터링 로직은 `/requests` 조회 API에 반영됨
- 프론트엔드에서 무한스크롤 + 필터 UI 연동 예정