### PR TITLE
modify: 토큰 페이로드에 isProfileCompleted 추가

### DIFF
--- a/src/services/authClient.service.ts
+++ b/src/services/authClient.service.ts
@@ -22,12 +22,14 @@ async function create(client: SignUpDataLocal) {
     email: newClient.email,
     name: newClient.name!,
     userType: newClient.userType,
+    isProfileCompleted: newClient?.isProfileCompleted,
   });
   const refreshToken = generateRefreshToken({
     userId: newClient.id,
     email: newClient.email,
     name: newClient.name!,
     userType: newClient.userType,
+    isProfileCompleted: newClient?.isProfileCompleted,
   });
 
   // 비밀번호와 전화번호 빼고 반환
@@ -52,6 +54,7 @@ async function loginWithLocal({ email, hashedPassword }: LoginDataLocal) {
     email: client.email,
     name: client.name!,
     userType: client.userType,
+    isProfileCompleted: client?.isProfileCompleted,
   });
 
   const refreshToken = generateRefreshToken({
@@ -59,6 +62,7 @@ async function loginWithLocal({ email, hashedPassword }: LoginDataLocal) {
     email: client.email,
     name: client.name!,
     userType: client.userType,
+    isProfileCompleted: client?.isProfileCompleted,
   });
 
   // 비밀번호와 전화번호 빼고 반환

--- a/src/services/authMover.service.ts
+++ b/src/services/authMover.service.ts
@@ -43,6 +43,7 @@ async function createMover(user: CreateMoverInput) {
       name: createdMover.name,
       phone: createdMover.phone,
       userType: createdMover.userType,
+      isProfileCompleted: createdMover?.isProfileCompleted,
     },
   };
 }
@@ -67,6 +68,7 @@ async function setMoverByEmail(user: GetMoverInput) {
     email: mover.email,
     name: mover.name!,
     userType: mover.userType,
+    isProfileCompleted: mover?.isProfileCompleted,
   });
 
   return {
@@ -83,7 +85,7 @@ async function setMoverByEmail(user: GetMoverInput) {
     email: mover?.email,
     nickName: mover?.nickName,
     userType: mover?.userType,
-    // profileCompleted: mover?.profileCompleted,
+    isProfileCompleted: mover?.isProfileCompleted,
   };
 }
 

--- a/src/types/token.type.ts
+++ b/src/types/token.type.ts
@@ -4,4 +4,5 @@ export type CreatedToken = {
   email: string;
   name: string;
   userType: string;
+  isProfileCompleted?: boolean;
 };

--- a/src/utils/token.util.ts
+++ b/src/utils/token.util.ts
@@ -9,6 +9,7 @@ export function generateAccessToken(user: CreatedToken): string {
     email: user.email,
     name: user.name,
     userType: user.userType,
+    isProfileCompleted: user.isProfileCompleted,
   };
 
   const accessSecret = process.env.JWT_SECRET;
@@ -31,6 +32,7 @@ export function generateRefreshToken(user: CreatedToken): string {
     email: user.email,
     name: user.name,
     userType: user.userType,
+    isProfileCompleted: user.isProfileCompleted,
   };
 
   const refreshSecret = process.env.JWT_SECRET;


### PR DESCRIPTION
## 작업 개요
- 토큰 페이로드에 isProfileCompleted 추가

---

## 작업 상세 내용
- [x] 토큰 생성 시 isProfileCompleted 상태 추가
- [x] 프로필 등록 시 `isProfileCompleted=true` 처리 및 토큰 재발급 
- [ ] 기사 프로필 등록 시 토큰 재발급 로직 추가 필요

---

## 🗂️ 수정한 파일
- `authClient.service.ts`
- `authMover.service-ts`
- `client.service.ts`
- `token.type.ts`
- `token.util.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- x
