### PR TITLE
feat: 기사 프로필 등록 시 토큰 재발급 로직 추가

### DIFF
--- a/src/controllers/profileMover.controller.ts
+++ b/src/controllers/profileMover.controller.ts
@@ -8,6 +8,8 @@ import { NextFunction, Request, Response } from "express";
 import profileMoverService from "../services/profileMover.service";
 import { filterSensitiveUserData } from "../utils/auth.util";
 import { MoverProfileDto } from "../dtos/mover.dto";
+import { NotFoundError } from "../types/errors";
+import { ErrorMessage } from "../constants/ErrorMessage";
 
 // TODO 삭제 예정//기사님 프로필 생성
 // async function moverCreateProfile(
@@ -43,8 +45,14 @@ async function moverPatchProfile(
       userId,
     });
 
-    const filteredMoverProfile = filterSensitiveUserData(updatedMoverProfile);
-    res.status(200).json(filteredMoverProfile);
+    if (!updatedMoverProfile) {
+      throw new NotFoundError(ErrorMessage.PROFILE_NOT_FOUND);
+    }
+
+    const { accessToken, refreshToken, ...rest } = updatedMoverProfile;
+
+    const filteredMoverProfile = filterSensitiveUserData(rest);
+    res.status(200).json({ ...filteredMoverProfile, accessToken, refreshToken });
   } catch (error) {
     next(error);
   }

--- a/src/repositories/authMover.repository.ts
+++ b/src/repositories/authMover.repository.ts
@@ -28,6 +28,13 @@ async function saveMover(user: CreateMoverInputwithHash) {
   return { ...createdMover, userType: "mover" }; //userType은 FE의 header에서 필요
 }
 
+// 아이디로 기사님 조회
+async function findMoverById(moverId: string) {
+  return await prisma.mover.findUnique({
+    where: { id: moverId },
+  });
+}
+
 //이메일로 기사님 조회
 async function getMoverByEmail(email: Mover["email"]) {
   const mover = await prisma.mover.findUnique({
@@ -53,6 +60,7 @@ async function getMoverByPhone(phone: Mover["phone"]) {
 
 export default {
   saveMover,
+  findMoverById,
   getMoverByEmail,
   getMoverByPhone,
 };

--- a/src/services/authMover.service.ts
+++ b/src/services/authMover.service.ts
@@ -26,12 +26,14 @@ async function createMover(user: CreateMoverInput) {
     email: createdMover.email,
     name: createdMover.name!,
     userType: createdMover.userType,
+    isProfileCompleted: createdMover?.isProfileCompleted,
   });
   const refreshToken = generateRefreshToken({
     userId: createdMover.id,
     email: createdMover.email,
     name: createdMover.name!,
     userType: createdMover.userType,
+    isProfileCompleted: createdMover?.isProfileCompleted,
   });
 
   return {
@@ -62,6 +64,7 @@ async function setMoverByEmail(user: GetMoverInput) {
     email: mover.email,
     name: mover.name!,
     userType: mover.userType,
+    isProfileCompleted: mover?.isProfileCompleted,
   });
   const refreshToken = generateRefreshToken({
     userId: mover.id,
@@ -76,16 +79,13 @@ async function setMoverByEmail(user: GetMoverInput) {
       userId: mover.id,
       email: mover.email,
       name: mover.name,
+      nickName: mover?.nickName,
       userType: mover.userType,
       phone: mover.phone,
+      isProfileCompleted: mover?.isProfileCompleted,
     },
     accessToken,
     refreshToken,
-    userId: mover?.id,
-    email: mover?.email,
-    nickName: mover?.nickName,
-    userType: mover?.userType,
-    isProfileCompleted: mover?.isProfileCompleted,
   };
 }
 


### PR DESCRIPTION
## 작업 개요
- 기사 프로필 등록 시 토큰 재발급 로직 추가

---

## 작업 상세 내용
- [x] moverId로 기사 정보 조회 함수 추가(`findMoverById`)
- [x] 기사 프로필 등록/수정 함수에 토큰 생성 로직 추가 

---

## 🗂️ 수정한 파일
- `profileMover.controller.ts`
- `authMover.repository.ts`
- `authMover.service.ts`
- `profileMover.service.ts`

---

## 🗂️ 새로 작성한 파일
x

---

## 기타 참고 사항
x
