### PR TITLE
feat: 선택적 인증 미들웨어 및 찜 상태 개선

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -45,7 +45,7 @@ app.use("/auth", authRouter);
 app.use("/profile", profileRouter);
 app.use("/dashboard", verifyAccessToken, accountRouter);
 app.use("/movers", moverRouter);
-app.use("/reviews", verifyAccessToken, reviewRouter);
+app.use("/reviews", reviewRouter);
 app.use("/estimates", verifyAccessToken, estimateRouter);
 app.use("/favorites", verifyAccessToken, favoriteRouter);
 app.use("/requests", requestRouter);

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -36,6 +36,24 @@ async function getMoverReviews(req: Request, res: Response, next: NextFunction) 
   }
 }
 
+// 특정 기사님에게 달린 리뷰 목록 조회 (공개용)
+async function getMoverReviewsById(req: Request, res: Response, next: NextFunction) {
+  try {
+    const { moverId } = req.params;
+    
+    const page = Number(req.query.page) || 1;
+    const limit = Number(req.query.limit) || 6;
+    
+    const result = await reviewService.getMoverReviews(moverId, page, limit);
+    res.status(200).json({
+      message: "기사님 리뷰 목록 조회 성공",
+      data: result,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
 // 리뷰 작성
 async function createReview(
   req: Request<{}, {}, CreateReviewDto>,
@@ -120,4 +138,5 @@ export default {
   updateReview,
   deleteReview,
   getWritableReviews,
+  getMoverReviewsById,
 };

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -117,6 +117,28 @@ export async function checkClientSignUpInfo(req: Request, res: Response, next: N
   }
 }
 
+// 선택적 인증 미들웨어 (토큰이 있으면 인증, 없어도 계속 진행)
+export const optionalAuth = (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    
+    if (authHeader && authHeader.startsWith('Bearer ')) {
+      const token = authHeader.substring(7);
+      
+      // JWT 검증
+      const jwt = require('jsonwebtoken');
+      const decoded = jwt.verify(token, secretKey);
+      req.auth = decoded; // 토큰이 유효하면 req.auth에 설정
+    }
+    
+    // 토큰이 없거나 유효하지 않아도 계속 진행
+    next();
+  } catch (error) {
+    // JWT 검증 실패해도 계속 진행 (req.auth는 undefined 상태)
+    next(error);
+  }
+};
+
 // ✅ 로그인 유효성 검사 미들웨어 - 쓸지 모르겠음
 // export async function checkClientSignInInfo(req: Request, res: Response, next: NextFunction) {
 //   try {

--- a/src/repositories/mover.repository.ts
+++ b/src/repositories/mover.repository.ts
@@ -35,8 +35,6 @@ async function fetchMovers(
     if (search) {
       whereCondition.OR = [
         { nickName: { contains: search, mode: "insensitive" } },
-        { name: { contains: search, mode: "insensitive" } },
-        { description: { contains: search, mode: "insensitive" } },
       ];
     }
 

--- a/src/routers/mover.router.ts
+++ b/src/routers/mover.router.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { verifyAccessToken } from "../middlewares/auth.middleware";
+import { verifyAccessToken, optionalAuth } from "../middlewares/auth.middleware";
 import moverController from '../controllers/mover.controller';
 
 const { 
@@ -12,13 +12,13 @@ const {
 const moverRouter = express.Router();
 
 // 전체 기사님 리스트 조회 (비회원도 가능)
-moverRouter.get('/', getMovers);
+moverRouter.get('/', optionalAuth, getMovers);
 
 // 기사님 본인 프로필 조회
 moverRouter.get('/profile', verifyAccessToken, getMoverProfile);
 
 // 기사님 상세 정보
-moverRouter.get('/:moverId', getMoverDetail);
+moverRouter.get('/:moverId', optionalAuth, getMoverDetail);
 
 // 기사님 찜 토글
 moverRouter.post('/:moverId/toggle-favorite', verifyAccessToken, toggleFavoriteMover);

--- a/src/routers/review.router.ts
+++ b/src/routers/review.router.ts
@@ -6,21 +6,24 @@ import { CreateReviewSchema, UpdateReviewschema } from "../dtos/review.dto";
 const reviewRouter = Router();
 
 // 내가 작성한 리뷰 목록
-reviewRouter.get("/me", reviewController.getMyReviews);
+reviewRouter.get("/me", verifyAccessToken , reviewController.getMyReviews);
 
-// 기사님에게 달린 리뷰 목록 (기사님용)
-reviewRouter.get("/mover", verifyAccessToken, reviewController.getMoverReviews);
+// 기사님에게 달린 리뷰 목록 (기사님용) - 본인
+reviewRouter.get("/mover", verifyAccessToken , reviewController.getMoverReviews);
+
+// 특정 기사님에게 달린 리뷰 목록 (공개용) - 일반유저가 확인
+reviewRouter.get("/mover/:moverId", reviewController.getMoverReviewsById);
 
 // 리뷰 작성
-reviewRouter.post("/", validateReq(CreateReviewSchema), reviewController.createReview);
+reviewRouter.post("/", verifyAccessToken , validateReq(CreateReviewSchema), reviewController.createReview);
 
 // 리뷰 수정
-reviewRouter.patch("/:reviewId", validateReq(UpdateReviewschema), reviewController.updateReview);
+reviewRouter.patch("/:reviewId", verifyAccessToken , validateReq(UpdateReviewschema), reviewController.updateReview);
 
 // 리뷰 삭제
-reviewRouter.delete("/:reviewId", reviewController.deleteReview);
+reviewRouter.delete("/:reviewId", verifyAccessToken , reviewController.deleteReview);
 
 // 작성 가능한 리뷰 목록
-reviewRouter.get("/writable", reviewController.getWritableReviews);
+reviewRouter.get("/writable", verifyAccessToken , reviewController.getWritableReviews);
 
 export default reviewRouter;


### PR DESCRIPTION
## 작업 개요
- 기사님 목록 API에서 로그인 사용자의 찜 상태를 올바르게 반환하도록 개선
- 비회원도 접근 가능하면서 로그인 시에는 찜 상태를 포함하는 선택적 인증 구현
- 상세페이지 기사님 리뷰api

---

## 작업 상세 내용
- [x] optionalAuth 미들웨어: 토큰이 있으면 인증, 없어도 계속 진행(비회원 접근 허용, 로그인 시 사용자 별 찜 구별 가능)
- [x] 로그인한 기사님 말고 상세페이지에서 특정 기사님의 리뷰 확인할 수 있는 api추가

---

## 🗂️ 수정한 파일
- `src/middlewares/auth.middleware.ts` - optionalAuth 미들웨어 추가
- `src/routes/mover.router.ts` - 선택적 인증 적용
- `src/routers/review.router.ts`

---

## 🗂️ 새로 작성한 파일

---

## 기타 참고 사항

