### PR TITLE
refactor: 알림 무한스크롤 구현 및 리팩토링

### DIFF
--- a/src/controllers/notification.controller.ts
+++ b/src/controllers/notification.controller.ts
@@ -6,9 +6,19 @@ import notificationService from "../services/notification.service";
 async function getNotifications(req: Request, res: Response, next: NextFunction) {
   try {
     const userId = req.auth!.userId;
-    const { list, hasUnread } = await notificationService.getNotifications(userId);
+    const { cursor, limit } = req.query as { cursor?: string; limit?: string };
+    const { list, hasUnread } = await notificationService.getNotifications(
+      userId,
+      cursor,
+      Number(limit),
+    );
 
-    res.json({ message: "알림 조회 성공", hasUnread, notifications: list });
+    res.json({
+      message: "알림 조회 성공",
+      hasUnread,
+      nextCursor: list.nextCursor,
+      notifications: list.notifications,
+    });
   } catch (error) {
     next(error);
   }

--- a/src/repositories/estimate.repository.ts
+++ b/src/repositories/estimate.repository.ts
@@ -172,7 +172,10 @@ async function findReceivedEstimatesByClientId(clientId: Client["id"]) {
 async function findEstimateByMoveDate(start: Date, end: Date) {
   return await prisma.estimate.findMany({
     where: {
+      moverStatus: "CONFIRMED",
+      isClientConfirmed: true,
       request: {
+        isPending: false,
         moveDate: {
           gte: start,
           lt: end,

--- a/src/repositories/notification.repository.ts
+++ b/src/repositories/notification.repository.ts
@@ -1,4 +1,3 @@
-import { skip } from "node:test";
 import prisma from "../configs/prisma.config";
 import { NotificationPayload } from "../types";
 

--- a/src/schedule/notification.cron.ts
+++ b/src/schedule/notification.cron.ts
@@ -3,10 +3,9 @@ import estimateRepository from "../repositories/estimate.repository";
 import { NotificationTemplate } from "../constants/NotificationTemplate";
 import notificationService from "../services/notification.service";
 import { addDays, startOfDay } from "date-fns";
-import { NotificationType } from "@prisma/client";
 
-cron.schedule("0 7 * * *", async () => {
-  console.log("🕖 Running moving day notification at 7AM");
+cron.schedule("0 0 * * *", async () => {
+  console.log("🕖 Running moving day notification at 9AM");
   const now = new Date();
   const today = startOfDay(now); // UTC 기준 오늘 00:00:00
   const tomorrow = addDays(today, 1);
@@ -16,50 +15,30 @@ cron.schedule("0 7 * * *", async () => {
     estimateRepository.findEstimateByMoveDate(today, tomorrow),
     estimateRepository.findEstimateByMoveDate(tomorrow, dayAftertomorrow),
   ]);
+  console.log("오늘 이사 견적 수: ", todayMoves.length);
+  console.log("내일 이사 견적 수: ", tomorrowMoves.length);
 
   // 당일 이사 알림
-  for (const estimate of todayMoves) {
-    const content = NotificationTemplate.MOVING_DAY(
-      estimate.request.fromAddress,
-      estimate.request.toAddress,
-      0,
-    );
-    await notificationService.sendAndSaveNotification({
-      userId: estimate.clientId,
-      content,
-      type: NotificationType.MOVING_DAY,
-      targetId: estimate.id,
-      targetUrl: `/my-quotes/client/${estimate.id}`,
-    });
-    await notificationService.sendAndSaveNotification({
-      userId: estimate.moverId,
-      content,
-      type: NotificationType.MOVING_DAY,
-      targetId: estimate.id,
-      targetUrl: `/my-quotes/mover/${estimate.id}`,
-    });
-  }
+  await Promise.all(
+    todayMoves.map((estimate) => {
+      const content = NotificationTemplate.MOVING_DAY(
+        estimate.request.fromAddress,
+        estimate.request.toAddress,
+        0,
+      );
+      return notificationService.notifyMovingDay(estimate, content);
+    }),
+  );
 
   // 내일 이사 알림
-  for (const estimate of tomorrowMoves) {
-    const content = NotificationTemplate.MOVING_DAY(
-      estimate.request.fromAddress,
-      estimate.request.toAddress,
-      1,
-    );
-    await notificationService.sendAndSaveNotification({
-      userId: estimate.clientId,
-      content,
-      type: NotificationType.MOVING_DAY,
-      targetId: estimate.id,
-      targetUrl: `/my-quotes/client/${estimate.id}`,
-    });
-    await notificationService.sendAndSaveNotification({
-      userId: estimate.moverId,
-      content,
-      type: NotificationType.MOVING_DAY,
-      targetId: estimate.id,
-      targetUrl: `/my-quotes/mover/${estimate.id}`,
-    });
-  }
+  await Promise.all(
+    tomorrowMoves.map((estimate) => {
+      const content = NotificationTemplate.MOVING_DAY(
+        estimate.request.fromAddress,
+        estimate.request.toAddress,
+        1,
+      );
+      return notificationService.notifyMovingDay(estimate, content);
+    }),
+  );
 });

--- a/src/services/estimate.service.ts
+++ b/src/services/estimate.service.ts
@@ -71,16 +71,20 @@ async function createEstimate({ price, comment, moverId, clientId, requestId }: 
       mover: { connect: { id: moverId } },
       request: { connect: { id: requestId } },
     },
+    include: {
+      request: true,
+    },
   });
 
-  // 견적 보낸 기사 조회
+  // 견적 보내는 기사 이름 조회
   const mover = await moverRepository.fetchMoverDetail(moverId);
 
-  // 견적 확정 알림 (to 유저)
-  await notificationService.notifyEstimateConfirmed({
-    userId: result.clientId,
-    moverName: mover.nickName!,
-    type: "ESTIMATE_CONFIRMED",
+  // 새로운 견적 알림 (to 유저)
+  await notificationService.notifyEstimate({
+    clientId,
+    moverName: mover!.name!,
+    moveType: result.request.moveType,
+    type: "NEW_ESTIMATE",
     targetId: result.id,
     targetUrl: `/my-quotes/client/${result.id}`,
   });
@@ -284,6 +288,18 @@ async function confirmEstimate(estimateId: string, clientId: string) {
     await estimateRepository.updateRequestPendingFalse(tx, estimate.request.id);
 
     return { estimateId, moverId: estimate.moverId };
+  });
+
+  // 견적 보낸 기사 조회
+  const mover = await moverRepository.fetchMoverDetail(result.moverId);
+
+  // 견적 확정 알림 (to 유저)
+  await notificationService.notifyEstimateConfirmed({
+    userId: clientId,
+    moverName: mover.nickName!,
+    type: "ESTIMATE_CONFIRMED",
+    targetId: estimateId,
+    targetUrl: `/my-quotes/client/${estimateId}`,
   });
 
   // 견적 요청한 유저 조회

--- a/src/services/estimate.service.ts
+++ b/src/services/estimate.service.ts
@@ -81,8 +81,8 @@ async function createEstimate({ price, comment, moverId, clientId, requestId }: 
     userId: result.clientId,
     moverName: mover.nickName!,
     type: "ESTIMATE_CONFIRMED",
-    targetId: requestId,
-    targetUrl: `/my-quotes/client/${requestId}`,
+    targetId: result.id,
+    targetUrl: `/my-quotes/client/${result.id}`,
   });
 
   return result;

--- a/src/services/request.service.ts
+++ b/src/services/request.service.ts
@@ -2,18 +2,14 @@ import { MoveType, RequestDraft } from "@prisma/client";
 import { CreateRequestDto } from "../dtos/request.dto";
 import requestRepository from "../repositories/request.repository";
 import { GetReceivedRequestsQuery } from "../types";
-import { BadRequestError, NotFoundError } from "../types/errors";
+import { BadRequestError } from "../types/errors";
 import { ErrorMessage } from "../constants/ErrorMessage";
 import authClientRepository from "../repositories/authClient.repository";
 import notificationService from "./notification.service";
 
 // 견적 요청 중간 상태 조회
 async function getDraft(clientId: string) {
-  const draft = await requestRepository.getRequestDraftById(clientId);
-  if (!draft) {
-    throw new NotFoundError(ErrorMessage.DRAFT_NOT_FOUND);
-  }
-  return draft;
+  return await requestRepository.getRequestDraftById(clientId);
 }
 
 // 견적 요청 중간 상태 저장

--- a/src/swagger.yaml
+++ b/src/swagger.yaml
@@ -115,6 +115,15 @@ paths:
       summary: 알림 목록 조회
       security:
         - bearerAuth: []
+      parameters:
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
       responses:
         "200":
           description: 조회 성공

--- a/src/types/notification.type.ts
+++ b/src/types/notification.type.ts
@@ -5,7 +5,13 @@ export interface NotifyInput {
   targetId: string;
   targetUrl: string;
 }
+
 export interface NotifyNewEstimate extends NotifyInput {
+  clientId: string;
+  moverName: string;
+  moveType: MoveType;
+}
+export interface NotifyNewRequest extends NotifyInput {
   clientName: string;
   fromAddress: string;
   toAddress: string;

--- a/src/utils/sse.util.ts
+++ b/src/utils/sse.util.ts
@@ -35,9 +35,8 @@ export function parseRegion(address: string): string {
   const parts = address.split(" ");
   const sido = parts[0].replace("시", ""); // "서울시" -> "서울"
   const sigungu = parts.find((p) => /[시군구]/.test(p)) || "";
-  const sigunguShort = sigungu.replace(/(시|군|구)/, "");
 
-  return `${sido}(${sigunguShort})`;
+  return `${sido}(${sigungu})`;
 }
 
 export function parseRegionKeywords(address: string): string[] {


### PR DESCRIPTION
## 작업 개요
- 알림 무한스크롤 로직 구현 58083e508c6f7b62a64416b45387894ba554c8fc
- 알림 생성 및 견적 요청 중간 저장 로직 일부 수정 72bff9469a210cd8eb0e85f9542968ec70959ff4
- 새로운 견적 알림 구현 0436c2dafa40b4dd5424d2a9b4d7958483d0e8df

---

## 작업 상세 내용
- [x] 알림 목록 조회 `cursor`, `limit` 쿼리 추가 및 `nextCursor` 반환
- [x] 이사 알림 스케줄러 코드 리팩토링
- [x] 견적 확정 알림 `targetId` requestId -> estimateId 로 수정
- [x] 이사 알림 생성되는 견적 조건 수정 
- [x] 견적 확정 및 새로운 견적 알림 생성 로직 수정
   - 기사 견적 보내기 -> 유저한테 새로운 견적 알림 생성
   - 유저 견적 확정 -> 기사 & 유저 견적 확정 알림 생성

---

## 🗂️ 수정한 파일
- `notification.controller.ts`, `notification.service.ts`, `notification.repository.ts`
- `swagger.yaml`
- `notification.cron.ts`
- `estimate.service.ts`, `estimate.repository.ts`
- `request.service.ts`
- `sse.util.ts` : 이사 알림에서 _**중구**_ 같은 경우 _**서울(중)**_ 으로 표시되는 부분 _**서울(중구)**_ 로 표시 되도록 수정

---

## 🗂️ 새로 작성한 파일
x

---

## 기타 참고 사항
x
