### PR TITLE
fix: 견적 요청 오류 수정 및 유닛 테스트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,4 +41,3 @@ jobs:
             npm run build
             pm2 kill
             pm2 start dist/app.js
-            echo "✓ Successfully deployed"

--- a/src/constants/ErrorMessage.ts
+++ b/src/constants/ErrorMessage.ts
@@ -22,6 +22,7 @@ export const ErrorMessage = {
   ALREADY_EXIST_PHONE: "이미 사용 중인 전화번호입니다.",
   ALREADY_EXIST_PROFILE: "이미 등록된 프로필입니다.",
   ALREADY_EXIST_USER: "이미 가입한 사용자입니다.",
+  ALREADY_EXIST_REQUEST: "이미 진행 중인 견적 요청이 있습니다.",
 
   // Invalid
   INVALID_EMAIL: "잘못된 이메일입니다.",

--- a/src/controllers/request.controller.ts
+++ b/src/controllers/request.controller.ts
@@ -77,14 +77,14 @@ async function getReceivedRequests(req: Request, res: Response, next: NextFuncti
   }
 }
 
-// 활성 요청 목록 조회 (일반)
-async function getClientActiveRequests(req: Request, res: Response, next: NextFunction) {
+// 활성 요청 조회 (일반 유저)
+async function getClientActiveRequest(req: Request, res: Response, next: NextFunction) {
   try {
-    const requests = await requestService.getClientActiveRequests(req.auth!.userId);
+    const request = await requestService.getClientActiveRequest(req.auth!.userId);
 
     res.status(200).json({
-      message: "활성 요청 목록 조회 성공",
-      requests,
+      message: "활성 요청 조회 성공",
+      request,
     });
   } catch (error) {
     console.error("활성 요청 조회 오류:", error);
@@ -107,6 +107,6 @@ export default {
   saveDraft,
   createRequest,
   getReceivedRequests,
-  getClientActiveRequests,
+  getClientActiveRequest,
   designateMover,
 };

--- a/src/repositories/request.repository.ts
+++ b/src/repositories/request.repository.ts
@@ -1,3 +1,4 @@
+import { startOfToday } from "date-fns";
 import prisma from "../configs/prisma.config";
 import { CreateRequestDto } from "../dtos/request.dto";
 import {
@@ -204,13 +205,21 @@ async function getFilteredRequests({
 }
 
 // 활성 견적 요청 조회
-async function fetchClientActiveRequests(clientId: string) {
-  return prisma.request.findMany({
+async function findPendingRequestById(clientId: string) {
+  const today = startOfToday();
+
+  return prisma.request.findFirst({
     where: {
       clientId,
-      isPending: true,
+      OR: [
+        { isPending: true },
+        {
+          moveDate: {
+            gte: today,
+          },
+        },
+      ],
     },
-    orderBy: { requestedAt: "desc" },
   });
 }
 
@@ -308,6 +317,6 @@ export default {
   saveRequestDraft,
   createEstimateRequest,
   getFilteredRequests,
-  fetchClientActiveRequests,
+  findPendingRequestById,
   designateMover,
 };

--- a/src/routers/request.router.ts
+++ b/src/routers/request.router.ts
@@ -16,7 +16,7 @@ requestRouter.post("/", requestController.createRequest);
 requestRouter.get("/", requestController.getReceivedRequests);
 
 // 받은 요청 조회 (일반 유저)
-requestRouter.get("/client/active", requestController.getClientActiveRequests);
+requestRouter.get("/client/active", requestController.getClientActiveRequest);
 
 // 기사님 지정 요청 (일반 > 기사)
 requestRouter.patch("/movers/:moverId", requestController.designateMover);

--- a/src/services/request.service.test.ts
+++ b/src/services/request.service.test.ts
@@ -1,0 +1,208 @@
+import requestRepository from "../repositories/request.repository";
+import authClientRepository from "../repositories/authClient.repository";
+import notificationService from "../services/notification.service";
+import { ErrorMessage } from "../constants/ErrorMessage";
+import { BadRequestError, GetReceivedRequestsQuery } from "../types";
+import requestService from "./request.service";
+import { MoveType, RequestDraft } from "@prisma/client";
+
+jest.mock("../repositories/request.repository");
+jest.mock("../repositories/authClient.repository");
+jest.mock("../services/notification.service");
+
+describe("견적 요청 중간 상태 조회 테스트", () => {
+  const clientId = "client-id-123";
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("유저 아이디에 해당하는 견적 요청 초안을 조회하는 함수를 호출하고 결과를 반환한다", async () => {
+    const mockDraft: RequestDraft = {
+      id: "draft-id-1",
+      clientId,
+      moveType: MoveType["SMALL"],
+      moveDate: new Date(),
+      fromAddress: "서울 강남구",
+      toAddress: "서울 송파구",
+      currentStep: 4,
+      updatedAt: new Date(),
+    };
+
+    (requestRepository.getRequestDraftById as jest.Mock).mockResolvedValue(mockDraft);
+
+    const result = await requestService.getDraft(clientId);
+
+    expect(requestRepository.getRequestDraftById).toHaveBeenCalledWith(clientId);
+    expect(result).toEqual(mockDraft);
+  });
+});
+
+describe("견적 요청 중간 상태 저장 테스트", () => {
+  const clientId = "client-id-456";
+  const draftData: Partial<RequestDraft> = {
+    moveType: "HOME",
+    fromAddress: "부산 해운대구",
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("유저의 견적 요청 초안을 업데이트하는 함수를 호출하고 결과를 반환한다", async () => {
+    const mockSavedDraft = { ...draftData, clientId };
+
+    (requestRepository.saveRequestDraft as jest.Mock).mockResolvedValue(mockSavedDraft);
+
+    const result = await requestService.saveDraft(clientId, draftData);
+
+    expect(requestRepository.saveRequestDraft).toHaveBeenCalledWith(clientId, draftData);
+    expect(result).toEqual(mockSavedDraft);
+  });
+});
+
+describe("일반 유저 견적 요청 테스트", () => {
+  const mockClientId = "client-id-123";
+  const mockRequestDto = {
+    moveType: MoveType["SMALL"],
+    moveDate: new Date(),
+    fromAddress: "서울 강남구",
+    toAddress: "서울 송파구",
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("활성 요청이 있으면 BadRequestError를 던진다", async () => {
+    (requestRepository.findPendingRequestById as jest.Mock).mockResolvedValue({ id: "existing" });
+
+    await expect(
+      requestService.createRequest({ clientId: mockClientId, request: mockRequestDto }),
+    ).rejects.toThrow(new BadRequestError(ErrorMessage.ALREADY_EXIST_REQUEST));
+
+    expect(requestRepository.findPendingRequestById).toHaveBeenCalledWith(mockClientId);
+    expect(requestRepository.createEstimateRequest).not.toHaveBeenCalled();
+  });
+
+  test("정상 요청일 경우 견적 요청 생성 및 알림 전송", async () => {
+    (requestRepository.findPendingRequestById as jest.Mock).mockResolvedValue(null);
+    (requestRepository.createEstimateRequest as jest.Mock).mockResolvedValue({
+      id: "new-request-1",
+    });
+    (authClientRepository.findById as jest.Mock).mockResolvedValue({ name: "홍길동" });
+    (notificationService.notifyEstimateRequest as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await requestService.createRequest({
+      clientId: mockClientId,
+      request: mockRequestDto,
+    });
+
+    expect(result).toEqual({ id: "new-request-1" });
+    expect(requestRepository.createEstimateRequest).toHaveBeenCalledWith(
+      mockRequestDto,
+      mockClientId,
+    );
+    expect(notificationService.notifyEstimateRequest).toHaveBeenCalledWith({
+      clientName: "홍길동",
+      fromAddress: "서울 강남구",
+      toAddress: "서울 송파구",
+      moveType: "SMALL",
+      type: "NEW_ESTIMATE",
+      targetId: "new-request-1",
+      targetUrl: `/my-quotes/mover/new-request-1`,
+    });
+  });
+});
+
+describe("기사님 받은 요청 목록 조회 테스트", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("moverId가 없으면 BadRequestError를 던진다", async () => {
+    const query = {
+      moveType: "SMALL",
+      moverId: undefined,
+    } as any;
+
+    await expect(requestService.getReceivedRequests(query)).rejects.toThrow(BadRequestError);
+  });
+
+  test("정상적인 파라미터로 repository를 호출한다", async () => {
+    const query: GetReceivedRequestsQuery = {
+      moverId: "mover123",
+      moveType: "SMALL,HOME",
+      isDesignated: "true",
+      serviceArea: "서울,경기",
+      keyword: "강남",
+      sort: "moveDate-desc",
+      limit: "10",
+      cursor: "abc",
+    };
+
+    const expectedArgs = {
+      moveType: ["SMALL", "HOME"] as MoveType[],
+      isDesignated: true,
+      serviceAreaList: ["서울", "경기"],
+      keyword: "강남",
+      sort: "moveDate-desc",
+      limit: 10,
+      cursor: "abc",
+      moverId: "mover123",
+    };
+
+    (requestRepository.getFilteredRequests as jest.Mock).mockResolvedValue(["mock"]);
+
+    const result = await requestService.getReceivedRequests(query);
+
+    expect(requestRepository.getFilteredRequests).toHaveBeenCalledWith(expectedArgs);
+    expect(result).toEqual(["mock"]);
+  });
+});
+
+describe("유저 활성 견적 요청 조회 테스트", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("clientId가 없으면 BadRequestError를 던진다", async () => {
+    await expect(requestService.getClientActiveRequest("")).rejects.toThrow(
+      "clientId가 필요합니다.",
+    );
+  });
+
+  test("clientId가 있으면 repository를 호출하고 응답을 반환한다", async () => {
+    (requestRepository.findPendingRequestById as jest.Mock).mockResolvedValue({ id: "req-1" });
+
+    const result = await requestService.getClientActiveRequest("client-123");
+
+    expect(requestRepository.findPendingRequestById).toHaveBeenCalledWith("client-123");
+    expect(result).toEqual({ id: "req-1" });
+  });
+});
+
+describe("지정 견적 요청 테스트", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("clientId, requestId, moverId 값이 하나라도 없으면 BadRequestError를 던진다", async () => {
+    await expect(requestService.designateMover("client", "", "mover")).rejects.toThrow(
+      "필수 값 누락",
+    );
+  });
+
+  test("세 값이 모두 있으면 repository를 호출한다", async () => {
+    (requestRepository.designateMover as jest.Mock).mockResolvedValue({ success: true });
+
+    const result = await requestService.designateMover("client-1", "request-1", "mover-1");
+
+    expect(requestRepository.designateMover).toHaveBeenCalledWith(
+      "request-1",
+      "mover-1",
+      "client-1",
+    );
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/src/services/request.service.ts
+++ b/src/services/request.service.ts
@@ -24,6 +24,13 @@ async function createRequest({
   request: CreateRequestDto;
   clientId: string;
 }) {
+  // 활성된 견적 요청 있는지 확인
+  const existing = await requestRepository.findPendingRequestById(clientId);
+
+  if (existing) {
+    throw new BadRequestError(ErrorMessage.ALREADY_EXIST_REQUEST);
+  }
+
   const newRequest = await requestRepository.createEstimateRequest(request, clientId);
 
   // 견적 요청한 유저 이름 조회
@@ -67,10 +74,10 @@ async function getReceivedRequests(query: GetReceivedRequestsQuery) {
   });
 }
 
-// 활성 견적 요청 조회 (일반)
-async function getClientActiveRequests(clientId: string) {
+// 활성 견적 요청 조회 (일반 유저)
+async function getClientActiveRequest(clientId: string) {
   if (!clientId) throw new BadRequestError("clientId가 필요합니다.");
-  return requestRepository.fetchClientActiveRequests(clientId);
+  return requestRepository.findPendingRequestById(clientId);
 }
 
 // 기사 지정
@@ -87,6 +94,6 @@ export default {
   saveDraft,
   createRequest,
   getReceivedRequests,
-  getClientActiveRequests,
+  getClientActiveRequest,
   designateMover,
 };

--- a/src/swagger.yaml
+++ b/src/swagger.yaml
@@ -465,7 +465,7 @@ paths:
   /requests/client/active:
     get:
       tags: [Request]
-      summary: 유저 활성 견적 요청 목록
+      summary: 유저 활성 견적 요청 조회
       security:
         - bearerAuth: []
       responses:


### PR DESCRIPTION
## 작업 개요
- 견적 요청 시 여러번 요청되는 오류 수정
- 견적 요청 서비스 로직 유닛 테스트 코드 작성

---

## 작업 상세 내용
- [x] 견적 요청 시 활성 견적을 조회하여 활성 견적이 있는 경우 요청이 불가능하도록 로직 수정
- [x] `request.service.test.ts` mock 기반 유닛 테스트 코드 작성

---

## 🗂️ 수정한 파일
- `deploy.yml`
- `ErrorMessage.ts`
- `request.router.ts`
- `request.controller.ts`
- `request.service.ts`
- `request.repository.ts`
- `swagger.yaml`

---

## 🗂️ 새로 작성한 파일
- `request.service.test.ts`

---

## 기타 참고 사항
- x
