### PR TITLE
feat: 내 견적 관리 탭 페이지네이션 적용 (6개씩 조회)

### DIFF
--- a/src/controllers/estimate.controller.ts
+++ b/src/controllers/estimate.controller.ts
@@ -121,20 +121,25 @@ async function rejectEstimate(req: Request, res: Response, next: NextFunction): 
 }
 
 // 보낸 견적 조회
-async function getSentEstimates(req: Request, res: Response, next: NextFunction): Promise<void> {
+async function getSentEstimates(req: Request, res: Response, next: NextFunction) {
   try {
-    const moverId = req.auth!.userId;
+    const moverId = req.auth?.userId;
+    const page = parseInt(req.query.page as string) || 1;
 
     if (!moverId) {
-      res.status(401).json({ message: "moverId (사용자 인증 정보)가 필요합니다." });
-      return;
+      return res.status(401).json({ message: "인증 필요" });
     }
 
-    const sentEstimates = await estimateService.findEstimatesByMoverId(moverId);
+    const { totalCount, totalPages, estimates } = await estimateService.getPaginatedSentEstimates(
+      moverId,
+      page,
+    );
 
     res.status(200).json({
       message: "보낸 견적 조회 성공",
-      data: sentEstimates,
+      totalCount,
+      totalPages,
+      data: estimates,
     });
   } catch (error) {
     console.error("보낸 견적 조회 실패:", error);
@@ -143,27 +148,28 @@ async function getSentEstimates(req: Request, res: Response, next: NextFunction)
 }
 
 // 반려한 견적 조회
-async function getRejectedEstimates(
-  req: Request,
-  res: Response,
-  next: NextFunction,
-): Promise<void> {
+async function getRejectedEstimates(req: Request, res: Response, next: NextFunction) {
   try {
-    const moverId = req.auth!.userId;
+    const moverId = req.auth?.userId;
+    const page = parseInt(req.query.page as string) || 1;
 
     if (!moverId) {
-      res.status(401).json({ message: "moverId (사용자 인증 정보)가 필요합니다." });
-      return;
+      return res.status(401).json({ message: "로그인 된 사용자가 없습니다." });
     }
 
-    const sentEstimates = await estimateService.getEstimatesByStatus(moverId);
+    const { totalCount, totalPages, estimates } = await estimateService.getRejectedEstimates(
+      moverId,
+      page,
+    );
 
     res.status(200).json({
-      message: "반려한 견적 조회 성공",
-      data: sentEstimates,
+      message: "반려된 견적 조회 성공",
+      totalCount,
+      totalPages,
+      data: estimates,
     });
   } catch (error) {
-    console.error("반려한 견적 조회 실패:", error);
+    console.error("반려 견적 조회 실패:", error);
     next(error);
   }
 }

--- a/src/repositories/estimate.repository.ts
+++ b/src/repositories/estimate.repository.ts
@@ -285,6 +285,112 @@ async function findConfirmedEstimate(requestId: string) {
   });
 }
 
+// 반려한 견적 조회
+const PAGE_SIZE = 6;
+
+async function getRejectedEstimates(moverId: string, page: number) {
+  const skip = (page - 1) * PAGE_SIZE;
+
+  const [totalCount, estimates] = await Promise.all([
+    prisma.estimate.count({
+      where: {
+        moverId,
+        moverStatus: "REJECTED",
+      },
+    }),
+    prisma.estimate.findMany({
+      where: {
+        moverId,
+        moverStatus: "REJECTED",
+      },
+      select: {
+        id: true,
+        price: true,
+        comment: true,
+        createdAt: true,
+        isClientConfirmed: true,
+        moverId: true,
+        request: {
+          select: {
+            moveDate: true,
+            fromAddress: true,
+            toAddress: true,
+            moveType: true,
+            client: {
+              select: { name: true },
+            },
+            designatedRequest: {
+              select: { moverId: true },
+            },
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+      skip,
+      take: PAGE_SIZE,
+    }),
+  ]);
+
+  return {
+    totalCount,
+    totalPages: Math.ceil(totalCount / PAGE_SIZE),
+    estimates,
+  };
+}
+
+// 보낸 견적 조회
+async function getPaginatedSentEstimates(moverId: string, page: number) {
+  const skip = (page - 1) * PAGE_SIZE;
+
+  const [totalCount, estimates] = await Promise.all([
+    prisma.estimate.count({
+      where: {
+        moverId,
+        moverStatus: "CONFIRMED",
+      },
+    }),
+    prisma.estimate.findMany({
+      where: {
+        moverId,
+        moverStatus: "CONFIRMED",
+      },
+      select: {
+        id: true,
+        price: true,
+        comment: true,
+        createdAt: true,
+        isClientConfirmed: true,
+        moverId: true,
+        request: {
+          select: {
+            moveDate: true,
+            fromAddress: true,
+            toAddress: true,
+            moveType: true,
+            client: {
+              select: { name: true },
+            },
+            designatedRequest: {
+              select: { moverId: true },
+            },
+          },
+        },
+      },
+      orderBy: { createdAt: "desc" },
+      skip,
+      take: PAGE_SIZE,
+    }),
+  ]);
+
+  return {
+    totalCount,
+    totalPages: Math.ceil(totalCount / PAGE_SIZE),
+    estimates,
+  };
+}
+
 export default {
   findWritableEstimatesByClientId,
   findPendingEstimatesByClientId,
@@ -298,4 +404,6 @@ export default {
   findEstimateDetailById,
   findConfirmedEstimate,
   updateRequestPendingFalse,
+  getRejectedEstimates,
+  getPaginatedSentEstimates,
 };

--- a/src/services/estimate.service.ts
+++ b/src/services/estimate.service.ts
@@ -108,42 +108,8 @@ async function rejectEstimate({ comment, moverId, clientId, requestId }: Estimat
 }
 
 // 보낸 견적 조회
-async function findEstimatesByMoverId(moverId: string) {
-  return prisma.estimate.findMany({
-    where: {
-      moverId,
-      moverStatus: "CONFIRMED",
-    },
-    select: {
-      id: true,
-      price: true,
-      comment: true,
-      createdAt: true,
-      isClientConfirmed: true,
-      moverId: true,
-      request: {
-        select: {
-          moveDate: true,
-          fromAddress: true,
-          toAddress: true,
-          moveType: true,
-          client: {
-            select: {
-              name: true,
-            },
-          },
-          designatedRequest: {
-            select: {
-              moverId: true,
-            },
-          },
-        },
-      },
-    },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
+async function getPaginatedSentEstimates(moverId: string, page: number) {
+  return estimateRepository.getPaginatedSentEstimates(moverId, page);
 }
 
 // 보낸 견적 상세 조회
@@ -183,42 +149,8 @@ async function findSentEstimateById(moverId: string, estimateId: string) {
 }
 
 // 반려한 견적 조회
-async function getEstimatesByStatus(moverId: string) {
-  return prisma.estimate.findMany({
-    where: {
-      moverId,
-      moverStatus: "REJECTED",
-    },
-    select: {
-      id: true,
-      price: true,
-      comment: true,
-      createdAt: true,
-      isClientConfirmed: true,
-      moverId: true,
-      request: {
-        select: {
-          moveDate: true,
-          fromAddress: true,
-          toAddress: true,
-          moveType: true,
-          client: {
-            select: {
-              name: true,
-            },
-          },
-          designatedRequest: {
-            select: {
-              moverId: true,
-            },
-          },
-        },
-      },
-    },
-    orderBy: {
-      createdAt: "desc",
-    },
-  });
+async function getRejectedEstimates(moverId: string, page: number) {
+  return await estimateRepository.getRejectedEstimates(moverId, page);
 }
 
 // client 받은 견적 조회
@@ -354,8 +286,8 @@ export default {
   createEstimate,
   findSentEstimateById,
   rejectEstimate,
-  findEstimatesByMoverId,
-  getEstimatesByStatus,
+  getPaginatedSentEstimates,
+  getRejectedEstimates,
   getReceivedEstimates,
   confirmEstimate,
   getEstimateDetail,


### PR DESCRIPTION
## 작업 개요
- 내 견적 관리 탭에서 데이터를 페이지네이션 방식으로 처리하도록 변경

---

## 작업 상세 내용
- [x] 전체 데이터를 한 번에 불러오던 기존 방식 제거
- [x] page 쿼리 파라미터 기반으로 6개씩 나눠서 응답하는 페이지네이션 로직 구현
- [x] controller → service → repository 레이어별로 기능 분리 및 정리 

---

## 🗂️ 수정한 파일
- `src/controllers/estimate.controller.ts`
- `src/services/estimate.service.ts`
- `src/repositories/estimate.repository.ts`
---


---

## 기타 참고 사항
- 유빈님 작성하신 페이지 네이션 컴포넌트 활용
