### PR TITLE
fix: 동일 이메일로 소셜 ↔ 소셜 가입 시 나오는 일반 오류 메시지를 적합하게 수정 (시도) 외

### DIFF
--- a/src/middlewares/passport/googleStrategy.ts
+++ b/src/middlewares/passport/googleStrategy.ts
@@ -51,12 +51,11 @@ async function verify(
     }
 
     done(null, userInfo); // req.user = user;
-  } catch (error) {
-    if (error instanceof BadRequestError) {
-      done(error);
-    } else {
-      done(new BadRequestError("소셜 로그인 중 오류가 발생했습니다."));
+  } catch (error: any) {
+    if (error.name === "Bad Request") {
+      return done(error);
     }
+    return done(new BadRequestError("소셜 로그인 중 오류가 발생했습니다."));
   }
 }
 

--- a/src/middlewares/passport/googleStrategy.ts
+++ b/src/middlewares/passport/googleStrategy.ts
@@ -37,14 +37,14 @@ async function verify(
         provider: providerEnumValue,
         providerId: profile.id,
         email: profile.emails[0].value,
-        name: profile.displayName,
+        name: "구글", // 구글 이름 안 받음
       });
     } else if (userType === "mover") {
       userInfo = await authMoverService.oAuthCreateOrUpdate({
         provider: providerEnumValue,
         providerId: profile.id,
         email: profile.emails[0].value,
-        name: profile.displayName,
+        name: "구글",
       });
     } else {
       throw new BadRequestError("소셜 로그인: userType을 식별하지 못했습니다.");

--- a/src/middlewares/passport/kakaoStrategy.ts
+++ b/src/middlewares/passport/kakaoStrategy.ts
@@ -55,12 +55,11 @@ async function verify(
     }
 
     done(null, userInfo); // req.user = user;
-  } catch (error) {
-    if (error instanceof BadRequestError) {
-      done(error);
-    } else {
-      done(new BadRequestError("소셜 로그인 중 오류가 발생했습니다."));
+  } catch (error: any) {
+    if (error.name === "Bad Request") {
+      return done(error);
     }
+    return done(new BadRequestError("소셜 로그인 중 오류가 발생했습니다."));
   }
 }
 

--- a/src/middlewares/passport/naverStrategy.ts
+++ b/src/middlewares/passport/naverStrategy.ts
@@ -50,12 +50,11 @@ async function verify(
     }
 
     done(null, userInfo); // req.user = user;
-  } catch (error) {
-    if (error instanceof BadRequestError) {
-      done(error);
-    } else {
-      done(new BadRequestError("소셜 로그인 중 오류가 발생했습니다."));
+  } catch (error: any) {
+    if (error.name === "Bad Request") {
+      return done(error);
     }
+    return done(new BadRequestError("소셜 로그인 중 오류가 발생했습니다."));
   }
 }
 

--- a/src/middlewares/rateLimits.middleware.ts
+++ b/src/middlewares/rateLimits.middleware.ts
@@ -10,8 +10,6 @@ export const loginLimiter = rateLimit({
   keyGenerator: (req, res) => {
     return `${req.body.email}`;
   },
-
-  // validate: false, // keyGenerator를 만들어 쓰면 IPv6 우회 때문에 검증 오류 발생(하는데 오류 아님). 검증 옵션을 꺼줌.
 });
 
 // (일반유저-프로필 페이지) 비밀번호 재설정 횟수 제한
@@ -21,15 +19,15 @@ export const profileUpdateLimit = rateLimit({
   limit: (req: Request) => {
     // 비밀번호는 1회, 일반 프로필 수정은 5회까지 허용
     const isPasswordChange = req.body.newPassword && req.body.newPassword.trim() !== "";
-    return isPasswordChange ? 1 : 5;
+    return isPasswordChange ? 3 : 10;
   },
 
   message: (req: Request) => {
     const isPasswordChange = req.body.newPassword && req.body.newPassword.trim() !== "";
     return {
       message: isPasswordChange
-        ? "비밀번호 재설정은 한 시간에 1회만 가능합니다."
-        : "프로필 수정은 한 시간에 5회까지만 가능합니다.",
+        ? "비밀번호 재설정은 한 시간에 3회만 가능합니다."
+        : "프로필 수정은 한 시간에 10회까지만 가능합니다.",
     };
   },
 
@@ -45,17 +43,17 @@ export const basicInfoUpdateLimit = rateLimit({
   windowMs: 60 * 60 * 1000, // 한 시간
 
   limit: (req: Request) => {
-    // 비밀번호는 1회, 기본정보 수정은 2회까지 허용
+    // 비밀번호는 3회, 기본정보 수정은 10회까지 허용
     const isPasswordChange = req.body.newPassword && req.body.newPassword.trim() !== "";
-    return isPasswordChange ? 1 : 2;
+    return isPasswordChange ? 3 : 10;
   },
 
   message: (req: Request) => {
     const isPasswordChange = req.body.newPassword && req.body.newPassword.trim() !== "";
     return {
       message: isPasswordChange
-        ? "비밀번호 재설정은 한 시간에 1회만 가능합니다."
-        : "기본정보 수정은 한 시간에 2회까지만 가능합니다.",
+        ? "비밀번호 재설정은 한 시간에 3회만 가능합니다."
+        : "기본정보 수정은 한 시간에 10회까지만 가능합니다.",
     };
   },
 


### PR DESCRIPTION
## 작업 개요
- 동일 이메일로 소셜 ↔ 소셜 가입 시 나오는 일반 오류 메시지를 적합하게 수정 (시도)

---

## 작업 상세 내용
- [x] 구글 로그인 시 이름을 "구글"로 받게 함
- [x] 프로필/기본정보 수정 페이지에서 비밀번호 등의 수정 가능 횟수 올림
- [x] 동일 이메일로 소셜 ↔ 소셜 가입 시 나오는 일반 오류 메시지를 적합하게 수정 (시도)

---

## 🗂️ 수정한 파일
- `src/middlewares/passport/googleStrategy.ts`
- `src/middlewares/passport/kakaoStrategy.ts`
- `src/middlewares/passport/naverStrategy.ts`
- `src/middlewares/rateLimits.middleware.ts`

---

## 🗂️ 새로 작성한 파일
- x
---

## 기타 참고 사항
- 이 PR 병합되면 성훈 님 한 번 오류 있던 부분 확인해 주세요.
