### PR TITLE
feat: redis 캐시 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "express-rate-limit": "^8.0.1",
         "figlet": "^1.8.1",
         "helmet": "^8.1.0",
+        "ioredis": "^5.7.0",
         "jsonwebtoken": "^9.0.2",
         "morgan": "^1.10.1",
         "multer": "^2.0.1",
@@ -2051,6 +2052,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.3.0.tgz",
+      "integrity": "sha512-M/T6Zewn7sDaBQEqIZ8Rb+i9y8qfGmq+5SDFSf9sA2lUZTmdDLVdOiQaeDp+Q4wElZ9HG1GAX5KhDaidp6LQsQ==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4871,6 +4878,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -5177,6 +5193,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -6285,6 +6310,30 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ioredis": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.7.0.tgz",
+      "integrity": "sha512-NUcA93i1lukyXU+riqEyPtSEkyFq8tX90uL659J+qpCZ3rEdViB/APC58oAhIh3+bJln2hzdlZbBZsGNrlsR8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.3.0",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
@@ -7354,6 +7403,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -7365,6 +7420,12 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
       "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
@@ -8565,6 +8626,27 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8988,6 +9070,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "seed": "ts-node prisma/seed.ts",
     "reset": "ts-node prisma/reset.ts",
     "ssh": "dotenv -- bash -c 'ssh -i \"$SSH_KEY_PATH\" -L 5432:$DB_HOST:5432 $EC2_USER@$EC2_HOST'",
+    "cache": "dotenv -- bash -c 'ssh -i \"$SSH_KEY_PATH\" -L 6379:$REDIS_HOST:6379 $EC2_USER@$EC2_HOST'",
     "test": "jest",
     "test:watch": "NODE_ENV=test jest --watchAll",
     "test:unit": "NODE_ENV=test DATABASE_URL=postgresql://postgres:password@localhost:5432/testdb jest --testPathIgnorePatterns=src/integration-test",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "express-rate-limit": "^8.0.1",
     "figlet": "^1.8.1",
     "helmet": "^8.1.0",
+    "ioredis": "^5.7.0",
     "jsonwebtoken": "^9.0.2",
     "morgan": "^1.10.1",
     "multer": "^2.0.1",

--- a/src/middlewares/cache.middleware.ts
+++ b/src/middlewares/cache.middleware.ts
@@ -12,18 +12,18 @@ redis.on("connect", () => console.log("✅ Redis 연결됨"));
 redis.on("ready", () => console.log("✅ Redis 준비됨"));
 redis.on("error", (err) => console.error("❌ Redis 오류: ", err));
 
-// 캐시 가져오는 조건
-const buildKey = (req: Request) => `cache:GET:${req.originalUrl}`;
-
 // 캐싱 미들웨어 함수 (TTL을 매개변수로 받음)
 export const cacheMiddleware = (ttl = 300) => {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
+      // 식별자
+      const userId = req.auth?.userId || undefined;
+      const cacheKey = `cache:${userId}:${req.originalUrl}`;
+
       // GET만 캐싱
       if (req.method !== "GET") return next();
 
       // Redis에서 캐시된 데이터 확인
-      const cacheKey = buildKey(req);
       const cachedData = await redis.get(cacheKey);
       console.log("cachedData 여부", !!cachedData);
 

--- a/src/middlewares/cache.middleware.ts
+++ b/src/middlewares/cache.middleware.ts
@@ -1,0 +1,82 @@
+import { Request, Response, NextFunction } from "express";
+import Redis from "ioredis";
+
+// Redis 클라이언트 생성
+const redis = new Redis({
+  host: process.env.NODE_ENV === "production" ? process.env.REDIS_HOST : "127.0.0.1",
+  port: Number(6379),
+});
+
+// 연결 상태 모니터링
+redis.on("connect", () => console.log("✅ Redis 연결됨"));
+redis.on("ready", () => console.log("✅ Redis 준비됨"));
+redis.on("error", (err) => console.error("❌ Redis 오류: ", err));
+
+// 캐시 가져오는 조건
+const buildKey = (req: Request) => `cache:GET:${req.originalUrl}`;
+
+// 캐싱 미들웨어 함수 (TTL을 매개변수로 받음)
+export const cacheMiddleware = (ttl = 300) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      // GET만 캐싱
+      if (req.method !== "GET") return next();
+
+      // Redis에서 캐시된 데이터 확인
+      const cacheKey = buildKey(req);
+      const cachedData = await redis.get(cacheKey);
+      console.log("cachedData 여부", !!cachedData);
+
+      if (cachedData) {
+        // 캐시된 데이터가 있으면 반환
+        res.setHeader("X-Cache", "HIT");
+        const parsedData = JSON.parse(cachedData);
+        return res.status(200).json(parsedData);
+      }
+
+      // 캐시된 데이터가 없으면 원본 응답을 캐시하도록 설정
+      res.setHeader("X-Cache", "MISS");
+      const originalJson = res.json;
+      res.json = function (data) {
+        // 응답 데이터를 Redis에 캐시 (TTL 설정)
+        if (res.statusCode === 200) {
+          // 200만 캐싱
+          redis.setex(cacheKey, ttl, JSON.stringify(data));
+        }
+
+        // 원본 json 메서드 호출
+        return originalJson.call(this, data);
+      };
+
+      next();
+    } catch (error) {
+      console.error("Cache middleware error:", error);
+      // Redis 에러가 발생해도 애플리케이션은 계속 동작하도록 next() 호출
+      next();
+    }
+  };
+};
+
+// 캐시 무효화 미들웨어 함수 (특정 URL만 무효화)
+export const invalidateCache = (url?: string) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (url) {
+        // 특정 URL의 캐시만 삭제
+        const cacheKey = `cache:${url}`;
+        await redis.del(cacheKey);
+        console.log(`Invalidated cache for: ${cacheKey}`);
+      } else {
+        // 현재 요청 URL의 캐시 삭제
+        const cacheKey = `cache:${req.originalUrl}`;
+        await redis.del(cacheKey);
+        console.log(`Invalidated cache for: ${cacheKey}`);
+      }
+
+      next();
+    } catch (error) {
+      console.error("Cache invalidation error:", error);
+      next();
+    }
+  };
+};

--- a/src/routers/auth.router.ts
+++ b/src/routers/auth.router.ts
@@ -15,6 +15,7 @@ import express from "express";
 import passport from "passport";
 import { createSocialAuthMiddleware } from "../middlewares/passport/passport.middleware";
 import { loginLimiter } from "../middlewares/rateLimits.middleware";
+import { cacheMiddleware } from "../middlewares/cache.middleware";
 
 const authRouter = express.Router();
 
@@ -22,7 +23,7 @@ const authRouter = express.Router();
 authRouter.post("/refresh-token", authController.setRefreshToken);
 
 // 사용자 불러오기
-authRouter.get("/", verifyAccessToken, authController.getMe);
+authRouter.get("/", verifyAccessToken, cacheMiddleware(300), authController.getMe);
 
 // 기사님 회원가입 - Local
 authRouter.post("/signup/mover", validateReq(signUpSchema), checkMoverSignUpInfo, moverSignup);

--- a/src/routers/estimate.router.ts
+++ b/src/routers/estimate.router.ts
@@ -1,6 +1,7 @@
 import estimateController from "../controllers/estimate.controller";
 import { Router, RequestHandler } from "express";
 import { translationMiddleware } from "../middlewares/translation.middleware";
+import { cacheMiddleware } from "../middlewares/cache.middleware";
 
 const estimateRouter = Router();
 
@@ -12,6 +13,7 @@ estimateRouter.get(
     "data.request.fromAddress",
     "data.request.toAddress",
   ]),
+  cacheMiddleware(300),
   estimateController.getPendingEstimates as RequestHandler,
 );
 
@@ -22,6 +24,7 @@ estimateRouter.post("/create", estimateController.sendEstimateToRequest);
 estimateRouter.get(
   "/sented/:id",
   translationMiddleware(["data.request.fromAddress", "data.request.toAddress"]),
+  cacheMiddleware(300),
   estimateController.getSentEstimateDetail,
 );
 
@@ -32,6 +35,7 @@ estimateRouter.post("/reject", estimateController.rejectEstimate);
 estimateRouter.get(
   "/sent",
   translationMiddleware(["data.comment", "data.request.fromAddress", "data.request.toAddress"]),
+  cacheMiddleware(300),
   estimateController.getSentEstimates,
 );
 
@@ -39,6 +43,7 @@ estimateRouter.get(
 estimateRouter.get(
   "/rejected",
   translationMiddleware(["data.comment", "data.request.fromAddress", "data.request.toAddress"]),
+  cacheMiddleware(300),
   estimateController.getRejectedEstimates,
 );
 
@@ -50,6 +55,7 @@ estimateRouter.get(
     "data.request.fromAddress",
     "data.request.toAddress",
   ]),
+  cacheMiddleware(300),
   estimateController.getReceivedEstimates as RequestHandler,
 );
 
@@ -60,11 +66,12 @@ estimateRouter.post("/confirmed", estimateController.confirmEstimate);
 estimateRouter.get(
   "/client/:estimateId",
   translationMiddleware(["data.comment", "data.request.fromAddress", "data.request.toAddress"]),
+  cacheMiddleware(300),
   estimateController.getEstimateDetail,
 );
 
 // 견적 상세 조회 (알림용)
-estimateRouter.get("/:estimateId", estimateController.getEstimateById);
+estimateRouter.get("/:estimateId", cacheMiddleware(300), estimateController.getEstimateById);
 
 // 견적 거절 및 요청 취소
 estimateRouter.delete("/:id", estimateController.deleteEstimate);

--- a/src/routers/favorite.router.ts
+++ b/src/routers/favorite.router.ts
@@ -1,9 +1,10 @@
 import favoriteController from "../controllers/favorite.controller";
 import { Router } from "express";
+import { cacheMiddleware } from "../middlewares/cache.middleware";
 
 const favoriteRouter = Router();
 
 // 찜한 기사님 목록
-favoriteRouter.get("/me", favoriteController.getFavoriteMovers);
+favoriteRouter.get("/me", cacheMiddleware(300), favoriteController.getFavoriteMovers);
 
 export default favoriteRouter;

--- a/src/routers/mover.router.ts
+++ b/src/routers/mover.router.ts
@@ -2,13 +2,20 @@ import moverController from "../controllers/mover.controller";
 import { optionalAuth, verifyAccessToken } from "../middlewares/auth.middleware";
 import express from "express";
 import { translationMiddleware } from "../middlewares/translation.middleware";
+import { cacheMiddleware } from "../middlewares/cache.middleware";
 
 const { getMovers, getMoverDetail, toggleFavoriteMover, getMoverProfile } = moverController;
 
 const moverRouter = express.Router();
 
 // 전체 기사님 리스트 조회 (비회원도 가능)
-moverRouter.get("/", optionalAuth, translationMiddleware(["movers.introduction"]), getMovers);
+moverRouter.get(
+  "/",
+  cacheMiddleware(300),
+  optionalAuth,
+  translationMiddleware(["movers.introduction"]),
+  getMovers,
+);
 
 // 기사님 본인 프로필 조회
 moverRouter.get(

--- a/src/routers/mover.router.ts
+++ b/src/routers/mover.router.ts
@@ -11,9 +11,9 @@ const moverRouter = express.Router();
 // 전체 기사님 리스트 조회 (비회원도 가능)
 moverRouter.get(
   "/",
-  cacheMiddleware(300),
   optionalAuth,
   translationMiddleware(["movers.introduction"]),
+  cacheMiddleware(300),
   getMovers,
 );
 
@@ -22,6 +22,7 @@ moverRouter.get(
   "/profile",
   verifyAccessToken,
   translationMiddleware(["data.introduction", "data.description"]),
+  cacheMiddleware(300),
   getMoverProfile,
 );
 
@@ -30,6 +31,7 @@ moverRouter.get(
   "/:moverId",
   optionalAuth,
   translationMiddleware(["introduction", "description"]),
+  cacheMiddleware(300),
   getMoverDetail,
 );
 

--- a/src/routers/notification.router.ts
+++ b/src/routers/notification.router.ts
@@ -1,16 +1,18 @@
 import notificationController from "../controllers/notification.controller";
 import { Router } from "express";
 import { translationMiddleware } from "../middlewares/translation.middleware";
+import { cacheMiddleware } from "../middlewares/cache.middleware";
 
 const notificationRouter = Router();
 
 // SSE 연결
-notificationRouter.get("/stream", notificationController.sendNotification);
+notificationRouter.get("/stream", cacheMiddleware(300), notificationController.sendNotification);
 
 // 알림 조회
 notificationRouter.get(
   "/",
   translationMiddleware(["notifications.content"]),
+  cacheMiddleware(300),
   notificationController.getNotifications,
 );
 

--- a/src/routers/request.router.ts
+++ b/src/routers/request.router.ts
@@ -1,6 +1,7 @@
 import requestController from "../controllers/request.controller";
 import { Router } from "express";
 import { translationMiddleware } from "../middlewares/translation.middleware";
+import { cacheMiddleware } from "../middlewares/cache.middleware";
 
 const requestRouter = Router();
 
@@ -8,6 +9,7 @@ const requestRouter = Router();
 requestRouter.get(
   "/draft",
   translationMiddleware(["data.fromAddress", "data.toAddress"]),
+  cacheMiddleware(300),
   requestController.getDraft,
 );
 
@@ -18,6 +20,7 @@ requestRouter.patch("/draft", requestController.saveDraft);
 requestRouter.get(
   "/client/active",
   translationMiddleware(["data.fromAddress", "data.toAddress"]),
+  cacheMiddleware(300),
   requestController.getClientActiveRequest,
 );
 
@@ -29,6 +32,7 @@ requestRouter.get(
     "requests.toAddress",
     "requests.estimates.comment",
   ]),
+  cacheMiddleware(300),
   requestController.getRequests,
 );
 
@@ -36,6 +40,7 @@ requestRouter.get(
 requestRouter.get(
   "/detail/:id",
   translationMiddleware(["request.fromAddress", "request.toAddress"]),
+  cacheMiddleware(300),
   requestController.getReceivedRequestDetail,
 );
 
@@ -46,6 +51,7 @@ requestRouter.patch("/movers/:moverId", requestController.designateMover);
 requestRouter.get(
   "/",
   translationMiddleware(["requests.fromAddress", "requests.toAddress"]),
+  cacheMiddleware(300),
   requestController.getReceivedRequests,
 );
 
@@ -56,6 +62,7 @@ requestRouter.post("/", requestController.createRequest);
 requestRouter.get(
   "/:id",
   translationMiddleware(["data.fromAddress", "data.toAddress"]),
+  cacheMiddleware(300),
   requestController.getRequest,
 );
 

--- a/src/routers/review.router.ts
+++ b/src/routers/review.router.ts
@@ -3,6 +3,7 @@ import { CreateReviewSchema, UpdateReviewschema } from "../dtos/review.dto";
 import { validateReq, verifyAccessToken } from "../middlewares/auth.middleware";
 import { Router } from "express";
 import { translationMiddleware } from "../middlewares/translation.middleware";
+import { cacheMiddleware } from "../middlewares/cache.middleware";
 
 const reviewRouter = Router();
 
@@ -11,6 +12,7 @@ reviewRouter.get(
   "/me",
   verifyAccessToken,
   translationMiddleware(["data.reviews.content"]),
+  cacheMiddleware(300),
   reviewController.getReviews,
 );
 
@@ -19,6 +21,7 @@ reviewRouter.get(
   "/mover",
   verifyAccessToken,
   translationMiddleware(["data.reviews.content"]),
+  cacheMiddleware(300),
   reviewController.getMoverOwnReviews,
 );
 
@@ -26,6 +29,7 @@ reviewRouter.get(
 reviewRouter.get(
   "/mover/:moverId",
   translationMiddleware(["data.reviews.content"]),
+  cacheMiddleware(300),
   reviewController.getReviews,
 );
 
@@ -49,6 +53,11 @@ reviewRouter.patch(
 reviewRouter.delete("/:reviewId", verifyAccessToken, reviewController.deleteReview);
 
 // 작성 가능한 리뷰 목록
-reviewRouter.get("/writable", verifyAccessToken, reviewController.getWritableReviews);
+reviewRouter.get(
+  "/writable",
+  verifyAccessToken,
+  cacheMiddleware(300),
+  reviewController.getWritableReviews,
+);
 
 export default reviewRouter;


### PR DESCRIPTION
## 작업 개요
- redis 캐시 적용

---

## 작업 상세 내용
- [x] redis 캐시 적용

---

## 🗂️ 수정한 파일
- `src/routers/auth.router.ts`
- `src/routers/estimate.router.ts`
- `src/routers/favorite.router.ts`
- `src/routers/mover.router.ts`
- `src/routers/notification.router.ts`
- `src/routers/request.router.ts`
- `src/routers/review.router.ts`
- `package.json`

---

## 🗂️ 새로 작성한 파일
- `src/middlewares/cache.middleware.ts`

---

## 기타 참고 사항
- GET 엔드포인트에 한해 캐시 적용했습니다.
- 앞으로 서버 시작 시 `npm run cache`를 같이 해주셔야 합니다.
