### PR TITLE
fix: 소셜 로그인 시 본래 이름을 덮어쓰는 오류 수정 외

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "6-moving-4team-be",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.840.0",

--- a/src/dtos/client.dto.ts
+++ b/src/dtos/client.dto.ts
@@ -1,6 +1,6 @@
 import { ErrorMessage } from "../constants/ErrorMessage";
 import { z } from "zod";
-import { emailSchema, nameSchema, phoneSchema } from "./auth.dto";
+import { nameSchema, phoneSchema } from "./auth.dto";
 
 // 개별 스키마
 export const profileImageSchema = z.string().optional();
@@ -14,8 +14,26 @@ export const livingAreaSchema = z
   .min(1, ErrorMessage.NO_REGION)
   .max(5, ErrorMessage.MAX_REGION);
 
-const passwordSchema = z.string().optional();
-const basicPasswordSchema = z.string().min(8, "기존 비밀번호를 입력해주세요.").optional();
+const passwordSchema = z
+  .string()
+  .min(8, ErrorMessage.PASSWORD_LENGTH_LIMIT)
+  .max(16, ErrorMessage.PASSWORD_LENGTH_LIMIT)
+  .regex(
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/,
+    ErrorMessage.PASSWORD_REGEX,
+  )
+  .optional()
+  .or(z.literal(""));
+const basicPasswordSchema = z
+  .string()
+  .min(8, ErrorMessage.PASSWORD_LENGTH_LIMIT)
+  .max(16, ErrorMessage.PASSWORD_LENGTH_LIMIT)
+  .regex(
+    /^(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>])[A-Za-z\d!@#$%^&*(),.?":{}|<>]{8,16}$/,
+    ErrorMessage.PASSWORD_REGEX,
+  )
+  .optional()
+  .or(z.literal(""));
 
 // 프로필 생성/수정을 함수로 분기처리 함
 export function profileClientSchema(mode: "create" | "update") {

--- a/src/services/authMover.service.ts
+++ b/src/services/authMover.service.ts
@@ -101,12 +101,11 @@ async function oAuthCreateOrUpdate(socialData: SignUpDataSocial) {
       throw new BadRequestError(`이미 ${existingUser.provider} 가입 시 사용된 이메일입니다.`);
     }
 
-    // 유저 있으면 provider, providerId, name, phone, email 업데이트
+    // 유저 있으면 provider, providerId, phone, email 업데이트 (이름은 넣으면 안 됨)
     const user = await authMoverRepository.createOrUpdate({
       id: existingUser.id,
       provider: socialData.provider,
       providerId: socialData.providerId,
-      name: socialData.name,
       email: socialData.email,
       phone: socialData.phone,
     });


### PR DESCRIPTION
## 작업 개요
- 기본 배포용 구조 세팅

---

## 작업 상세 내용
- [x] 소셜 로그인 시 본래 이름을 덮어쓰는 오류 수정
- [x] 고객 프로필 수정 시 비밀번호 유효성 검사 조건 변경(FE에 맞춤)

---

## 🗂️ 수정한 파일
- `src/dtos/client.dto.ts`
- `src/services/authMover.service.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- x
