### PR TITLE
fix: 커뮤니티 댓글 기사 닉네임으로 수정

### DIFF
--- a/src/repositories/community.repository.ts
+++ b/src/repositories/community.repository.ts
@@ -137,11 +137,10 @@ async function updateReply(id: string, content: string) {
     where: { id },
     data: {
       content,
-      // updatedAt: new Date(), // 수정 시간 업데이트
     },
     include: {
       client: { select: { id: true, name: true, profileImage: true } },
-      mover: { select: { id: true, name: true, profileImage: true } },
+      mover: { select: { id: true, nickName: true, profileImage: true } },
     },
   });
 }
@@ -197,7 +196,7 @@ async function findRepliesByCommunityId(communityId: string) {
     where: { communityId },
     include: {
       client: { select: { id: true, name: true, profileImage: true } },
-      mover: { select: { id: true, name: true, profileImage: true } },
+      mover: { select: { id: true, nickName: true, profileImage: true } },
     },
     orderBy: { createdAt: "desc" },
   });
@@ -209,7 +208,7 @@ async function findRepliesByCommunityId(communityId: string) {
     clientId: reply.clientId,
     moverId: reply.moverId,
     communityId: reply.communityId,
-    userNickname: reply.client?.name || reply.mover?.name || "익명",
+    userNickname: reply.client?.name || reply.mover?.nickName || "익명",
     profileImg: reply.client?.profileImage || reply.mover?.profileImage || null,
   }));
 }


### PR DESCRIPTION
## 작업 개요
- 커뮤니티 댓글 기사 닉네임으로 수정

---

## 작업 상세 내용
- [x] 기존 백엔드에서 커뮤니티 댓글 작성자가 기사일 경우 `name`으로 반환하던 부분 -> `nickName`으로 수정

---

## 🗂️ 수정한 파일
- `src/repositories/community.repository.ts`

---

## 🗂️ 새로 작성한 파일
- x

---

## 기타 참고 사항
- x
